### PR TITLE
removing unecessary printing for inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - respecting Client "quiet" attribute in run_command  (0.0.34)
  - adding missing import of tempfile in image.export (0.0.33)
  - bug with Client.version() (0.0.32)
  - fixing bugs with import, export, image commands (0.0.31)

--- a/spython/main/base/command.py
+++ b/spython/main/base/command.py
@@ -109,10 +109,10 @@ def run_command(self, cmd, sudo=False, quiet=False, capture=True):
        cmd: the command to run
        sudo: does the command require sudo?
        On success, returns result. Otherwise, exists on error
-    
-    '''
+       quiet: suppress printing to the console
 
-    result = run_cmd(cmd, sudo=sudo, capture=capture)
+    '''
+    result = run_cmd(cmd, sudo=sudo, capture=capture, quiet=quiet)
     message = result['message']
     return_code = result['return_code']
         

--- a/spython/main/inspect.py
+++ b/spython/main/inspect.py
@@ -47,6 +47,6 @@ def inspect(self,image=None, json=True, app=None):
         cmd.append('--json')
 
     cmd.append(image)
-    output = self._run_command(cmd)
+    output = self._run_command(cmd, quiet=self.quiet)
     #self.println(output,quiet=self.quiet)    
     return output

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -43,7 +43,7 @@ def check_install(software='singularity', quiet=True):
     found = False
 
     try:
-        version = run_command(cmd)
+        version = run_command(cmd, quiet=True)
     except: # FileNotFoundError
         return found
 
@@ -95,7 +95,7 @@ def stream_command(cmd, no_newline_regexp="Progess", sudo=False):
         raise subprocess.CalledProcessError(return_code, cmd)
 
 
-def run_command(cmd, sudo=False, capture=True, no_newline_regexp="Progess"):
+def run_command(cmd, sudo=False, capture=True, no_newline_regexp="Progess", quiet=False):
     '''run_command uses subprocess to send a command to the terminal. If
        capture is True, we use the parent stdout, so the progress bar (and
        other commands of interest) are piped to the user. This means we 
@@ -132,10 +132,13 @@ def run_command(cmd, sudo=False, capture=True, no_newline_regexp="Progess"):
                 line = line.decode('utf-8')
             lines = lines + (line,)
             if re.search(no_newline_regexp, line) and found_match is True:
-                sys.stdout.write(line)
+                if quiet is False:
+                    sys.stdout.write(line)
                 found_match = True
             else:
-                print(line.rstrip())
+                if quiet is False:
+                    sys.stdout.write(line)
+                    print(line.rstrip())
                 found_match = False
 
     output = {'message': lines,

--- a/spython/version.py
+++ b/spython/version.py
@@ -18,7 +18,7 @@
 
 
 
-__version__ = "0.0.33"
+__version__ = "0.0.34"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This tweak will honor the client's quiet level when running "run_command" - currently we spit out the output no matter what!