### PR TITLE
Fix/recipe bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - fixing bug with recipe Dockerfile conversion (0.0.37)
  - typo in pypi PACKAGE_URL (0.0.36)
  - respecting Client "quiet" attribute in run_command  (0.0.34/0.0.35)
  - adding missing import of tempfile in image.export (0.0.33)

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -115,8 +115,6 @@ class DockerRecipe(Recipe):
         line = self._setup('ARG', line)
         bot.warning("ARG is not supported for Singularity! To get %s" %line[0])
         bot.warning("in the container, on host export SINGULARITY_%s" %line[0])
-        self.install.append(line[0])
-
 
 # Env Parser
 

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -98,7 +98,25 @@ class DockerRecipe(Recipe):
 
         '''
         self.test  = self._setup('HEALTHCHECK', line)
-        
+
+
+# Arg Parser
+
+    def _arg(self, line):
+        '''singularity doesn't have support for ARG, so instead will issue
+           a warning to the console for the user to export the variable
+           with SINGULARITY prefixed at build.
+ 
+           Parameters
+           ==========
+           line: the line from the recipe file to parse for ARG
+   
+        '''
+        line = self._setup('ARG', line)
+        bot.warning("ARG is not supported for Singularity! To get %s" %line[0])
+        bot.warning("in the container, on host export SINGULARITY_%s" %line[0])
+        self.install.append(line[0])
+
 
 # Env Parser
 
@@ -398,6 +416,7 @@ class DockerRecipe(Recipe):
         cmd = line[0].upper()
 
         mapping = {"ADD": self._add,
+                   "ARG": self._arg,
                    "COPY": self._copy,
                    "CMD": self._cmd,
                    "ENTRYPOINT": self._entry,
@@ -411,7 +430,7 @@ class DockerRecipe(Recipe):
                    "VOLUME": self._volume,
                    "LABEL": self._label}
 
-        # If it's a command line, return correct functoin
+        # If it's a command line, return correct function
         if cmd in mapping:
             return mapping[cmd]
 
@@ -447,7 +466,6 @@ class DockerRecipe(Recipe):
         for line in self.lines:
 
             parser = self._get_mapping(line, parser, previous)
-
 
             # Parse it, if appropriate
             if parser:

--- a/spython/main/parse/environment.py
+++ b/spython/main/parse/environment.py
@@ -55,7 +55,12 @@ def parse_env(envlist):
             elif '=' in current:
                 exports.append(current)
 
-            # Case 1: ['A', 'B']  --> A=B
+            # Case 3: ENV \\
+
+            elif current.endswith('\\'):
+                continue
+
+            # Case 4: ['A', 'B']  --> A=B
 
             else:
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -18,7 +18,7 @@
 
 
 
-__version__ = "0.0.36"
+__version__ = "0.0.37"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
hey @bbarker this should fix the following two issues, to close #39 :

 - bug when you try to parse ENV from continued line  (`ENV \\`)
 - issuing a warning when using ARG

Could you please give it a test and let me know if we should do any further changes? Thanks again for the catch and helping out here!