### PR TITLE
changed strip to rstrip for image remove uri function

### DIFF
--- a/.travis/before_install
+++ b/.travis/before_install
@@ -18,5 +18,5 @@ which python
 python setup.py sdist && python setup.py install
 
 # Install Singularity (development)
-cd /tmp && git clone https://github.com/singularityware/singularity.git && cd singularity && ./autogen.sh && ./configure --prefix=/usr/local && make && sudo make install
+cd /tmp && git clone -b vault/release-2.5 https://github.com/singularityware/singularity.git && cd singularity && ./autogen.sh && ./configure --prefix=/usr/local && make && sudo make install
 

--- a/spython/image/__init__.py
+++ b/spython/image/__init__.py
@@ -56,7 +56,7 @@ class ImageBase(object):
         image = image or ''
         uri = self.get_uri(image) or ''
         image = image.replace('%s://' %uri,'', 1)
-        return image.strip('-').strip('/')
+        return image.strip('-').rstrip('/')
 
 
     def parse_image_name(self, image):


### PR DESCRIPTION
The strip removes the / symbol from the beginning of the location to load the image. This removal results in trimmed absolute paths not available for loading the container image