### PR TITLE
Changed stdout to None

### DIFF
--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -124,6 +124,9 @@ def run_command(cmd,
     if capture is True:
         stdout = subprocess.PIPE
 
+    if "instance.start" in cmd:
+        stdout = None
+
     # Use the parent stdout and stderr
     process = subprocess.Popen(cmd, 
                                stderr = subprocess.PIPE, 

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -124,7 +124,7 @@ def run_command(cmd,
     if capture is True:
         stdout = subprocess.PIPE
 
-    if "instance.start" in cmd: 
+    if "instance.start" in cmd:
         stdout = None
 
     # Use the parent stdout and stderr

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -124,7 +124,7 @@ def run_command(cmd,
     if capture is True:
         stdout = subprocess.PIPE
 
-    if "instance.start" in cmd:
+    if "instance.start" in cmd: 
         stdout = None
 
     # Use the parent stdout and stderr


### PR DESCRIPTION
Added None type for stdout for run_command function


```
from spython.main import Client
image_loc = Client.pull(image="shub://jekriske/lolcow:lowfat",name="lolcow.simg")
myinstance = Client.instance(image=image_loc,name="lolcow")
print(myinstance)
result = Client.run(myinstance)
```

The above code hangs indefinitely if the stdout=subprocess.PIPE is used in the command.

The subprocess.PIPE method somehow ends up with a buffer fill error and hangs indefinitely for me. Maybe it is a machine issue in Ubuntu. Maybe the output is empty and that could be reason why it hangs.

This issue has been explained in different places like [here](https://www.reddit.com/r/Python/comments/1vbie0/subprocesspipe_will_hang_indefinitely_if_stdout/) and [here](https://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/)
