### PR TITLE
fixing client bug, cli --> client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - fixing bug in shell.py, cli should be client (0.0.40)
  - remove uri function should only right strip to support relative paths (0.0.39)
  - adjusting container build to use correct Github branch (vault/release-2.5)
  - adding support and documentation for container instances (0.0.38)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Singularity Python
 
-Singularity Python is the Python API for working with <a href="https://singularityware.github.io" target="_blank">Singularity</a> containers. See
+Singularity Python (spython) is the Python API for working with <a href="https://singularityware.github.io" target="_blank">Singularity</a> containers. See
 the [documentation](https://singularityhub.github.io/singularity-cli) for installation and usage. 
 
-We provide a [Singularity](Singularity) recipe for you to use if more convenient, along with the [full modules docstring](https://singularityhub.github.io/singularity-cli/api/source/spython.main.base.html#module-spython.main.base). This formatting will improve.
+We provide a [Singularity](Singularity) recipe for you to use if more convenient, along with the [full modules docstring](https://singularityhub.github.io/singularity-cli/api/source/spython.main.base.html#module-spython.main.base).
 
 ## License
+
 This code is licensed under the Affero GPL, version 3.0 or later [LICENSE](LICENSE).
 
 ## Help and Contribution

--- a/spython/client/shell.py
+++ b/spython/client/shell.py
@@ -73,7 +73,7 @@ def bpython(image):
     client.DockerRecipe = DockerRecipe
     client.SingularityRecipe = SingularityRecipe
 
-    bpython.embed(locals_={'client': cli})
+    bpython.embed(locals_={'client': client})
 
 def python(image):
     import code
@@ -87,4 +87,4 @@ def python(image):
     client.DockerRecipe = DockerRecipe
     client.SingularityRecipe = SingularityRecipe
 
-    code.interact(local={"client":cli})
+    code.interact(local={"client":client})

--- a/spython/version.py
+++ b/spython/version.py
@@ -18,7 +18,7 @@
 
 
 
-__version__ = "0.0.39"
+__version__ = "0.0.40"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will fix a bug that the client is imported as "client" and not "cli" in the shell function, given that the user has bypython or standard python. It's been missed because **most** have ipython. This will fix #55 .