### PR TITLE
Add --nv flag to run and execute commands.

### DIFF
--- a/spython/main/execute.py
+++ b/spython/main/execute.py
@@ -30,7 +30,8 @@ def execute(self,
             writable = False,
             contain = False,
             bind = None,
-            stream = False):
+            stream=False,
+            nv=False):
 
     ''' execute: send a command to a container
     
@@ -46,6 +47,7 @@ def execute(self,
         bind: list or single string of bind paths.
              This option allows you to map directories on your host system to
              directories within your container using bind mounts
+        nv: if True, load Nvidia Drivers in Runtime.
 
     '''
     from spython.utils import check_install
@@ -53,6 +55,10 @@ def execute(self,
 
     cmd = self._init_command('exec')
 
+    # It option leverage the GPU card
+    if nv is True:
+        cmd += ['--nv']
+    
     # If the image is given as a list, it's probably the command
     if isinstance(image, list):
         command = image

--- a/spython/main/run.py
+++ b/spython/main/run.py
@@ -29,7 +29,8 @@ def run(self,
         writable = False,
         contain = False,
         bind = None,
-        stream = False):
+        stream=False,
+        nv=False):
 
     '''
         run will run the container, with or withour arguments (which
@@ -47,12 +48,16 @@ def run(self,
               This option allows you to map directories on your host system to
               directories within your container using bind mounts
         stream: if True, return <generator> for the user to run
-
+        nv: if True, load Nvidia Drivers in Runtime.
     '''
     from spython.utils import check_install
     check_install()
 
     cmd = self._init_command('run')
+   
+    # It option leverage the GPU card
+    if nv is True:
+        cmd += ['--nv']
 
     # No image provided, default to use the client's loaded image
     if image is None:


### PR DESCRIPTION
- add a simple new flag, test in my local machine, I can't create a Test for Travis because I do not know the GPU model where Travis is running, so I can not install drivers obviously :) .
- the other PR is a mistake, I forgot the **[ ]**  :(

`$spython shell`
**Test 1:**

```
from spython.main import Client as cl

cl.load('/data/dk/containers/test/test_nv.simg')
executor = cl.execute(command=['nvidia-smi'], nv=True, stream=True)
for line in executor:
      print(line)
```
**Test 2**
```
from spython.main import Client as cl

cl.load('/data/dk/containers/test/test_nv.simg')
executor = cl.run(nv=True, stream=True)
for line in executor:
      print(line)
```
___

**Output**
```
Thu Sep  6 23:43:07 2018

+-----------------------------------------------------------------------------+

| NVIDIA-SMI 367.128                Driver Version: 367.128                   |

|-------------------------------+----------------------+----------------------+

| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |

| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |

|===============================+======================+======================|

|   0  GRID K2             Off  | 0000:0C:00.0     Off |                  Off |

...
```

my test Singularity recipe:

```
BootStrap: docker

From: centos:latest

%labels
  name "test --nv flag" 

%post
  cd /mnt

%runscript
  exec nvidia-smi

```