### PR TITLE
fixing bug with instances starting hanging!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - issue #64 bug with hanging instances (0.0.44)
  - flexible error printing given command to terminal fails (0.0.43)
  - adding name_by_commit and name_by_hash to pull (0.0.42)
  - adding nvidia flag as nv argument (with default False) to run/exec (0.0.41)

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -19,7 +19,7 @@
 from spython.logger import bot
 import sys
 
-def start(self, image=None, name=None, sudo=False, options=[]):
+def start(self, image=None, name=None, sudo=False, options=[], capture=False):
     '''start an instance. This is done by default when an instance is created.
 
        Parameters
@@ -27,6 +27,7 @@ def start(self, image=None, name=None, sudo=False, options=[]):
        image: optionally, an image uri (if called as a command from Client)
        name: a name for the instance
        sudo: if the user wants to run the command with sudo
+       capture: capture output, default is False. With True likely to hang.
        options: a list of tuples, each an option to give to the start command
                 [("--bind", "/tmp"),...]
 
@@ -65,7 +66,7 @@ def start(self, image=None, name=None, sudo=False, options=[]):
     self.options = options
     self.cmd = cmd
 
-    output = run_command(cmd, sudo=sudo, quiet=True)
+    output = run_command(cmd, sudo=sudo, quiet=True, capture=capture)
 
     if output['return_code'] == 0:
         self._update_metadata()

--- a/spython/version.py
+++ b/spython/version.py
@@ -18,7 +18,7 @@
 
 
 
-__version__ = "0.0.43"
+__version__ = "0.0.44"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
The bug was trying to capture the output, which hangs because we are starting a separate process namespace I think. The fix is to set capture to False.