### PR TITLE
fixing bug with copy to support multiple src src dest (and not other …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - COPY command should honor src src dest (and not reverse) (0.0.47)
  - ENV variables in Dockerfile can be empty (like unsetting) (0.0.46)
  - COPY can handle multiple sources to one destination for Dockerfile parser (0.0.45)
  - Adding DockerRecipe, SingularityRecipe "load" action to load file

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -154,8 +154,8 @@ class DockerRecipe(Recipe):
 
         for line in lines:
             values = line.split(" ")
-            frompath = values.pop(0)
-            for topath in values:
+            topath = values.pop()
+            for frompath in values:
                 self._add_files(frompath, topath)
         
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -16,7 +16,7 @@
 
 
 
-__version__ = "0.0.46"
+__version__ = "0.0.47"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will resolve the issue mentioned in #73 . Specifically, we are expecting the copy command to take the format `<src> <dest> <dest>` and in fact it should be `<src> <src> <dest>`