### PR TITLE
updating instances to support singularity instances subgroup >= 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - adding support for instance list (0.0.47)
  - ENV variables in Dockerfile can be empty (like unsetting) (0.0.46)
  - COPY can handle multiple sources to one destination for Dockerfile parser (0.0.45)
  - Adding DockerRecipe, SingularityRecipe "load" action to load file

--- a/docs/pages/commands-instances.md
+++ b/docs/pages/commands-instances.md
@@ -10,6 +10,7 @@ This section will discuss interaction with container instances, which generally
 includes starting, stopping and running. From within python, you can instantiate
 an sphython client, and then use the following functions to control an Instance:
 
+ - [version](#singularity-version): control the instance command subgroup
  - [Shell](#shell) gives you an interactive python shell with a client
  - [Start](#create-an-instance) create a Singularity instance!
  - [Commands](#commands) how to interact with your instance (run, exec)
@@ -22,6 +23,22 @@ of instances. While this listing doesn't directly link to finding an Instance th
 have created, you can find based on the name (shown later in the documentation).
 
 <hr>
+
+## Singularity Version
+After Singularity 3.0, the instances command subgroup changed so that the original
+call to interact with instances might have looked like "instances.list". After 3.0,
+the [instances subgroup](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md#v300---20181008)
+changed to be of the format "instances list." Singularity Python determines this 
+automatically by looking at your Singularity version, however if you want to control
+the final command that is used (for one reason or another) you can also export
+the environment variable:
+
+```bash
+export SPYTHON_SINGULARITY_VERSION=2.6
+```
+
+Would change behavior of the client for Singularity instances. This currently
+only has this changed behavior for the instances subgroup.
 
 ## Shell
 All of the commands below start with creating an spython client:

--- a/spython/image/cmd/__init__.py
+++ b/spython/image/cmd/__init__.py
@@ -54,5 +54,3 @@ def generate_image_commands():
  
     cli = ImageClient()
     return cli
-
-image_group = generate_image_commands()

--- a/spython/instance/__init__.py
+++ b/spython/instance/__init__.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
 from spython.image import ImageBase
 import os
 

--- a/spython/instance/cmd/__init__.py
+++ b/spython/instance/cmd/__init__.py
@@ -46,5 +46,3 @@ def generate_instance_commands():
     Instance.instance = Instance
  
     return Instance
-
-instance_group = generate_instance_commands()

--- a/spython/instance/cmd/iutils.py
+++ b/spython/instance/cmd/iutils.py
@@ -46,10 +46,16 @@ def get(self, name, return_json=False, quiet=False):
     '''get is a list for a single instance. It is assumed to be running,
        and we need to look up the PID, etc.
     '''
-    from spython.utils import check_install
+    from spython.utils import ( check_install, get_singularity_version )
     check_install()
 
-    cmd = self._init_command('instance.list')
+    # Ensure compatible for singularity prior to 3.0, and after 3.0
+    subgroup = "instance.list"
+    if get_singularity_version().startswith("3"):
+        subgroup = ["instance", "list"]
+
+    cmd = self._init_command(subgroup)
+
     cmd.append(name)
     output = run_command(cmd, quiet=True)
 

--- a/spython/instance/cmd/iutils.py
+++ b/spython/instance/cmd/iutils.py
@@ -51,7 +51,7 @@ def get(self, name, return_json=False, quiet=False):
 
     # Ensure compatible for singularity prior to 3.0, and after 3.0
     subgroup = "instance.list"
-    if get_singularity_version().startswith("3"):
+    if get_singularity_version().find("version 3"):
         subgroup = ["instance", "list"]
 
     cmd = self._init_command(subgroup)

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -34,7 +34,9 @@ def start(self, image=None, name=None, sudo=False, options=[], capture=False):
        singularity [...] instance.start [...] <container path> <instance name>
 
     '''        
-    from spython.utils import ( run_command, check_install )
+    from spython.utils import ( run_command, 
+                                check_install, 
+                                get_singularity_version )
     check_install()
 
     # If no name provided, give it an excellent one!
@@ -52,7 +54,12 @@ def start(self, image=None, name=None, sudo=False, options=[], capture=False):
 
         image = self._image
 
-    cmd = self._init_command('instance.start')
+    # Derive subgroup command based on singularity version
+    subgroup = 'instance.start'
+    if get_singularity_version().startswith("3"):
+        subgroup = ["instance", "start"]
+
+    cmd = self._init_command(subgroup)
 
     # Add options, if they are provided
     if not isinstance(options, list):

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -56,7 +56,7 @@ def start(self, image=None, name=None, sudo=False, options=[], capture=False):
 
     # Derive subgroup command based on singularity version
     subgroup = 'instance.start'
-    if get_singularity_version().startswith("3"):
+    if get_singularity_version().find("version 3"):
         subgroup = ["instance", "start"]
 
     cmd = self._init_command(subgroup)

--- a/spython/instance/cmd/stop.py
+++ b/spython/instance/cmd/stop.py
@@ -38,7 +38,7 @@ def stop(self, name=None, sudo=False):
     check_install()
 
     subgroup = 'instance.stop'
-    if get_singularity_version().startswith("3"):
+    if get_singularity_version().find("version 3"):
         subgroup = ["instance", "stop"]
 
     cmd = self._init_command(subgroup)

--- a/spython/instance/cmd/stop.py
+++ b/spython/instance/cmd/stop.py
@@ -32,10 +32,16 @@ def stop(self, name=None, sudo=False):
        singularity [...] instance.start [...] <container path> <instance name>
 
     '''        
-    from spython.utils import ( check_install, run_command )
+    from spython.utils import ( check_install, 
+                                run_command, 
+                                get_singularity_version )
     check_install()
 
-    cmd = self._init_command('instance.stop')
+    subgroup = 'instance.stop'
+    if get_singularity_version().startswith("3"):
+        subgroup = ["instance", "stop"]
+
+    cmd = self._init_command(subgroup)
 
     # If name is provided assume referencing an instance
     instance_name = self.name

--- a/spython/main/__init__.py
+++ b/spython/main/__init__.py
@@ -52,12 +52,12 @@ def get_client(quiet=False, debug=False):
     Client.pull = pull
 
     # Command Groups, Images
-    from spython.image.cmd import image_group        # deprecated image commands
-    Client.image = image_group
+    from spython.image.cmd import generate_image_commands  # deprecated
+    Client.image = generate_image_commands()
 
     # Commands Groups, Instances
-    from spython.instance.cmd import instance_group  # instance level commands
-    Client.instance = instance_group
+    from spython.instance.cmd import generate_instance_commands  # instance level commands
+    Client.instance = generate_instance_commands()
     Client.instance_stopall = stopall
 
     # Initialize

--- a/spython/main/base/command.py
+++ b/spython/main/base/command.py
@@ -43,7 +43,7 @@ def init_command(self, action, flags=None):
 
     if not isinstance(action, list):
         action = [action]      
-    cmd = ['singularity'] + [action]
+    cmd = ['singularity'] + action
 
     if self.quiet is True:
         cmd.insert(1, '--quiet')

--- a/spython/main/base/command.py
+++ b/spython/main/base/command.py
@@ -32,18 +32,18 @@ import re
 
 
 def init_command(self, action, flags=None):
-    '''
-        return the initial Singularity command with any added flags.
+    '''return the initial Singularity command with any added flags.
         
-        Parameters
-        ==========
-        action: the main action to perform (e.g., build)
-        flags: one or more additional flags (e.g, volumes) 
-               not implemented yet.
-
+       Parameters
+       ==========
+       action: the main action to perform (e.g., build)
+       flags: one or more additional flags (e.g, volumes) 
+              not implemented yet.
     '''
 
-    cmd = ['singularity', action ]
+    if not isinstance(action, list):
+        action = [action]      
+    cmd = ['singularity'] + [action]
 
     if self.quiet is True:
         cmd.insert(1, '--quiet')
@@ -123,4 +123,3 @@ def run_command(self, cmd, sudo=False, capture=True):
     if self.quiet is False:
         bot.error("Return Code %s: %s" %(return_code,
                                          message))
-

--- a/spython/main/instances.py
+++ b/spython/main/instances.py
@@ -43,7 +43,7 @@ def instances(self, name=None, return_json=False, quiet=False):
     check_install()
 
     subgroup = 'instance.list'
-    if get_singularity_version().startswith("3"):
+    if get_singularity_version().find("version 3"):
         subgroup = ["instance", "list"]
 
     cmd = self._init_command(subgroup)

--- a/spython/main/instances.py
+++ b/spython/main/instances.py
@@ -16,7 +16,7 @@
 
 
 from spython.logger import bot
-from spython.utils import run_command, check_install
+from spython.utils import ( run_command, check_install, get_singularity_version )
 
 def instances(self, name=None, return_json=False, quiet=False):
     '''list instances. For Singularity, this is provided as a command sub
@@ -42,7 +42,11 @@ def instances(self, name=None, return_json=False, quiet=False):
     from spython.utils import check_install
     check_install()
 
-    cmd = self._init_command('instance.list')
+    subgroup = 'instance.list'
+    if get_singularity_version().startswith("3"):
+        subgroup = ["instance", "list"]
+
+    cmd = self._init_command(subgroup)
 
     # If the user has provided a name, we want to see a particular instance
     if name is not None:

--- a/spython/tests/test_utils.py
+++ b/spython/tests/test_utils.py
@@ -81,6 +81,17 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(not is_not_installed)
 
 
+    def test_check_get_singularity_version(self):
+        '''check that the singularity version is found to be that installed'''
+        print("Testing utils.get_singularity_version")
+        from spython.utils import get_singularity_version
+        version = get_singularity_version()
+        self.assertTrue(version != "")
+        os.environ['SPYTHON_SINGULARITY_VERSION'] = "3.0"
+        version = get_singularity_version()
+        self.assertTrue(version == "3.0")
+
+
     def test_get_installdir(self):
         '''get install directory should return the base of where singularity
         is installed

--- a/spython/utils/__init__.py
+++ b/spython/utils/__init__.py
@@ -9,6 +9,7 @@ from .fileio import (
 from .terminal import ( 
     check_install, 
     get_installdir,
+    get_singularity_version,
     stream_command,
     run_command,
     format_container_name,

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -56,6 +56,24 @@ def check_install(software='singularity', quiet=True):
     return found
 
 
+def get_singularity_version():
+    '''get the singularity client version. Useful in the case that functionality
+       has changed, etc. Can be "hacked" if needed by exporting 
+       SPYTHON_SINGULARITY_VERSION, which is checked before checking on the
+       command line.
+    '''
+    version = os.environ.get('SPYTHON_SINGULARITY_VERSION', "")
+    if version == "":
+        try:
+            version = run_command(["singularity", '--version'], quiet=True)
+        except: # FileNotFoundError
+            return version
+
+        if version['return_code'] == 0:
+            version = version['message'][0].strip('\n')
+
+    return version
+
 def get_installdir():
     '''get_installdir returns the installation directory of the application
     '''

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -70,7 +70,8 @@ def get_singularity_version():
             return version
 
         if version['return_code'] == 0:
-            version = version['message'][0].strip('\n')
+            if len(version['message']) > 0:
+                version = version['message'][0].strip('\n')
 
     return version
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -16,7 +16,7 @@
 
 
 
-__version__ = "0.0.46"
+__version__ = "0.0.47"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will address the [change](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md#v300---20181008) for Singularity 3.0 that the instances subgroup is no longer one string, joined by period.
E.g., the old "singularity instance.list" is now "singularity instance list".

To support both versions for the user, we derive behavior of this client based on the singularity --version returned by the host. If the host wants to override this behavior, the environment variable `SPYTHON_SINGULARITY_VERSION` can be exported, e.g.,

```bash
export SPYTHON_SINGULARITY_VERSION=3.0
```
This will close #75 