### PR TITLE
fixing bug to parse newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - continued lines should not be split in docker.py recipe parser (_setup) (0.0.49)
  - COPY command should honor src src dest (and not reverse) (0.0.48)
  - adding support for instance list (0.0.47)
  - ENV variables in Dockerfile can be empty (like unsetting) (0.0.46)

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -428,7 +428,7 @@ class DockerRecipe(Recipe):
         previous = self._clean_line(previous)
 
         # if we are continuing from last
-        if cleaned.endswith('\\') and parser or previous.endswith('\\'): #or previous.endswith('\\\n'):
+        if cleaned.endswith('\\') and parser or previous.endswith('\\'):
             return parser
 
         return self._default

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -48,7 +48,10 @@ class DockerRecipe(Recipe):
         bot.debug('[in]  %s' % line)
 
         # Replace ACTION at beginning
-        line = re.sub('^%s' %action, '', line)
+        line = re.sub('^%s' % action, '', line)
+
+        # Handle continuation lines without ACTION by padding with leading space
+        line = " " + line
 
         # Split into components
         return [x for x in self._split_line(line) if x not in ['', None]]
@@ -372,25 +375,7 @@ class DockerRecipe(Recipe):
         self.labels += [ label ]
 
 
-# Main Parsing Functions
-
-
-    def _split_line(self, line):
-        '''clean a line to prepare it for parsing, meaning separation
-           of the Docker command (e.g., RUN) from the remainder. We remove
-           newlines (from ends) along with extra spaces.
-
-           Parameters
-           ==========
-           line: the string to parse into parts
-    
-           Returns
-           =======
-           parts: a list of line pieces, the command is likely first
-
-        '''
-        return [x.strip() for x in line.split(' ', 1)]
-        
+# Main Parsing Functions        
 
 
     def _get_mapping(self, line, parser=None, previous=None):
@@ -443,7 +428,7 @@ class DockerRecipe(Recipe):
         previous = self._clean_line(previous)
 
         # if we are continuing from last
-        if cleaned.endswith('\\') and parser or previous.endswith('\\'):
+        if cleaned.endswith('\\') and parser or previous.endswith('\\'): #or previous.endswith('\\\n'):
             return parser
 
         return self._default

--- a/spython/version.py
+++ b/spython/version.py
@@ -16,7 +16,7 @@
 
 
 
-__version__ = "0.0.48"
+__version__ = "0.0.49"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will fix a bug that newlines in a Docker recipe are split excessively given that there isn't a command to parse. I'm not entirely confident in the fix (it seems like it might break other recipes) but the fix is overall to add a superficial space before the command so it isn't split as if it were an action. The issue is reported in #77 please test on other recipes (preferably with continued lined) to test. Thanks!