### PR TITLE
Fix long description content type for PYPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ if __name__ == "__main__":
           license=LICENSE,
           description=DESCRIPTION,
           long_description=LONG_DESCRIPTION,
+          long_description_content_type="text/markdown",
           keywords=KEYWORDS,
           setup_requires=["pytest-runner"],
           tests_require=["pytest"],


### PR DESCRIPTION
Hi,

Saw the description of the project in PYPI, and also #79. I contribute to a project that also displays its `README.md` as long description. But in order for the formatting to be correctly rendered, we needed to set the content type [in the setup.py](https://github.com/metomi/isodatetime/blob/master/setup.py).

This pull request simply adds that to the `setup.py` here too :-)

Cheers
Bruno