### PR TITLE
quick addition to support args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - additional of args to instance start commands (0.0.50)
  - continued lines should not be split in docker.py recipe parser (_setup) (0.0.49)
  - COPY command should honor src src dest (and not reverse) (0.0.48)
  - adding support for instance list (0.0.47)

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -9,7 +9,7 @@
 from spython.logger import bot
 import sys
 
-def start(self, image=None, name=None, sudo=False, options=[], capture=False):
+def start(self, image=None, name=None, args=None, sudo=False, options=[], capture=False):
     '''start an instance. This is done by default when an instance is created.
 
        Parameters
@@ -18,6 +18,7 @@ def start(self, image=None, name=None, sudo=False, options=[], capture=False):
        name: a name for the instance
        sudo: if the user wants to run the command with sudo
        capture: capture output, default is False. With True likely to hang.
+       args: arguments to provide to the instance (supported Singularity 3.1+)
        options: a list of tuples, each an option to give to the start command
                 [("--bind", "/tmp"),...]
 
@@ -59,8 +60,15 @@ def start(self, image=None, name=None, sudo=False, options=[], capture=False):
     # Assemble the command!
     cmd = cmd + options + [image, self.name]
 
+    # If arguments are provided
+    if args != None:
+        if not isinstance(args, list):
+            args = [args]
+        cmd = cmd + args
+
     # Save the options and cmd, if the user wants to see them later
     self.options = options
+    self.args = args
     self.cmd = cmd
 
     output = run_command(cmd, sudo=sudo, quiet=True, capture=capture)

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.49"
+__version__ = "0.0.50"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This pull request will add an additional argument, args, to the instance start command (from within python) so the user can choose to provide arguments to the instance.