### PR TITLE
fixing issue with instances, should return one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - fixing bug with instances list, name not taken into account (0.0.51)
  - additional of args to instance start commands (0.0.50)
  - continued lines should not be split in docker.py recipe parser (_setup) (0.0.49)
  - COPY command should honor src src dest (and not reverse) (0.0.48)

--- a/spython/instance/cmd/iutils.py
+++ b/spython/instance/cmd/iutils.py
@@ -42,7 +42,8 @@ def get(self, name, return_json=False, quiet=False):
 
     # Ensure compatible for singularity prior to 3.0, and after 3.0
     subgroup = "instance.list"
-    if get_singularity_version().find("version 3"):
+
+    if 'version 3' in get_singularity_version():
         subgroup = ["instance", "list"]
 
     cmd = self._init_command(subgroup)

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -48,7 +48,7 @@ def start(self, image=None, name=None, args=None, sudo=False, options=[], captur
 
     # Derive subgroup command based on singularity version
     subgroup = 'instance.start'
-    if get_singularity_version().find("version 3"):
+    if 'version 3' in get_singularity_version():
         subgroup = ["instance", "start"]
 
     cmd = self._init_command(subgroup)

--- a/spython/instance/cmd/stop.py
+++ b/spython/instance/cmd/stop.py
@@ -9,7 +9,6 @@
 from spython.logger import bot
 import sys
 
-
 def stop(self, name=None, sudo=False):
     '''start an instance. This is done by default when an instance is created.
 
@@ -29,7 +28,8 @@ def stop(self, name=None, sudo=False):
     check_install()
 
     subgroup = 'instance.stop'
-    if get_singularity_version().find("version 3"):
+
+    if 'version 3' in get_singularity_version():
         subgroup = ["instance", "stop"]
 
     cmd = self._init_command(subgroup)

--- a/spython/instance/cmd/stop.py
+++ b/spython/instance/cmd/stop.py
@@ -14,12 +14,11 @@ def stop(self, name=None, sudo=False):
 
        Parameters
        ==========
-       image: optionally, an image uri (if called as a command from Client)
        name: a name for the instance
        sudo: if the user wants to run the command with sudo
 
        USAGE: 
-       singularity [...] instance.start [...] <container path> <instance name>
+       singularity [...] instance.stop [...] <instance name>
 
     '''        
     from spython.utils import ( check_install, 

--- a/spython/instance/cmd/stop.py
+++ b/spython/instance/cmd/stop.py
@@ -10,7 +10,7 @@ from spython.logger import bot
 import sys
 
 def stop(self, name=None, sudo=False):
-    '''start an instance. This is done by default when an instance is created.
+    '''stop an instance. This is done by default when an instance is created.
 
        Parameters
        ==========

--- a/spython/main/instances.py
+++ b/spython/main/instances.py
@@ -64,6 +64,12 @@ def instances(self, name=None, return_json=False, quiet=False):
         if return_json is False:
             for i in instances:
                 
+                # If the user has provided a name, only add instance matches
+                if name != None:
+                    if name != i['daemon_name']:
+                        continue
+
+                # Otherwise, add instances to the listing
                 new_instance = self.instance(pid=i['pid'],
                                              name=i['daemon_name'],
                                              image=i['container_image'],
@@ -82,7 +88,7 @@ def instances(self, name=None, return_json=False, quiet=False):
         bot.info('No instances found.')
 
     # If we are given a name, return just one
-    if name is not None and instances is not None:
+    if name != None and instances not in [None,[]]:
         if len(instances) == 1:
             instances = instances[0]
 

--- a/spython/main/instances.py
+++ b/spython/main/instances.py
@@ -34,7 +34,8 @@ def instances(self, name=None, return_json=False, quiet=False):
     check_install()
 
     subgroup = 'instance.list'
-    if get_singularity_version().find("version 3"):
+
+    if 'version 3' in get_singularity_version():
         subgroup = ["instance", "list"]
 
     cmd = self._init_command(subgroup)

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.50"
+__version__ = "0.0.51"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This PR will fix the Client.instances() command so that if the user provides a name, a single instance is returned instead of a list. This will close #83 