### PR TITLE
fixing instance name missing when not started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - Fixing bug with instance not having name when not started (0.0.56)
+   - instance start has been moved to non-private
  - Added ability for exec and run to return the full output and message (0.0.55)
   - By default, oci commands (pause, resume, kill) return the return value
  - Added support and tests for OCI image command group (0.0.54)

--- a/spython/instance/cmd/__init__.py
+++ b/spython/instance/cmd/__init__.py
@@ -30,7 +30,7 @@ def generate_instance_commands():
     Instance._run_command = run_command
     Instance._list = instances  # list command is used to get metadata
     Instance._println = println
-    Instance._start = start     # intended to be called on init, not by user
+    Instance.start = start     # intended to be called on init, not by user
     Instance.stop = stop
 
     # Give an instance the ability to breed :)

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -29,10 +29,9 @@ def start(self, image=None, name=None, args=None, sudo=False, options=[], captur
                                 check_install )
     check_install()
 
-    # If no name provided, give it an excellent one!
-    if name is None:
-        name = self.RobotNamer.generate()
-    self.name = name.replace('-','_')
+    # If name provided, over write robot (default)
+    if name != None:
+        self.name = name
 
     # If an image isn't provided, we have an initialized instance
     if image is None:

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.55"
+__version__ = "0.0.56"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will fix a bug that an instance doesn't have a name if it isn't started. The instance is given a robot name on init, and if the user starts the instance with start() the name will be overridden. This will close #97 

Another update here is changing the instance._start() to instance.start() because it's a reasonable function for the user to want to interact with, and thus shouldn't be private.