### PR TITLE
Fixing files warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - fixing warning for files, only relevant for sources (0.0.59)
  - deprecating pulling by commit or hash, not supported for Singularity (0.0.58)
    - export command added back, points to build given Singularity 3.x+
  - print but with logger, should be println (0.0.57)

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -208,9 +208,14 @@ class DockerRecipe(Recipe):
             if path == ".":
                 paths[pathtype] = os.getcwd()
  
-            # Warning if doesn't exist
-            if not os.path.exists(path):
-                bot.warning("%s doesn't exist, ensure exists for build" %path)
+            # Warn the user Singularity doesn't support expansion
+            if path.contains('*'):
+                bot.warning("Singularity doesn't support expansion, * found in %s" % path)
+
+            # Warning if file/folder (src) or parent (dest) doesn't exist
+            parent = os.path.dirname(path)
+            if not os.path.exists(path) and not os.path.exists(parent)):
+                bot.warning("%s doesn't exist, ensure exists for build" % path)
 
         # The pair is added to the files as a list
         self.files.append([paths['source'], paths['dest']])

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -212,9 +212,8 @@ class DockerRecipe(Recipe):
             if path.contains('*'):
                 bot.warning("Singularity doesn't support expansion, * found in %s" % path)
 
-            # Warning if file/folder (src) or parent (dest) doesn't exist
-            parent = os.path.dirname(path)
-            if not os.path.exists(path) and not os.path.exists(parent)):
+            # Warning if file/folder (src) doesn't exist
+            if pathtype == "source" and not os.path.exists(path):
                 bot.warning("%s doesn't exist, ensure exists for build" % path)
 
         # The pair is added to the files as a list

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.58"
+__version__ = "0.0.59"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will fix issues #101 and #102, specifically:

 - we check that the parent of a files source or destination AND the source destination doesn't exist to issue a warning. Previously, we were issuing a warning if the destination didn't exist, which isn't logical. It won't :)
 - we give the user a warning for any file expansions (*) as Singularity doesn't allow this.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>