### PR TITLE
Don't warn if dest file/folder does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - fixing warning for files, only relevant for sources (0.0.59)
  - deprecating pulling by commit or hash, not supported for Singularity (0.0.58)
    - export command added back, points to build given Singularity 3.x+
  - print but with logger, should be println (0.0.57)

--- a/spython/main/parse/converters.py
+++ b/spython/main/parse/converters.py
@@ -11,6 +11,8 @@ import os
 import re
 import sys
 
+from spython.logger import bot
+
 # Singularity to Dockerfile
 # Easier, parsed line by line
 

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -199,21 +199,19 @@ class DockerRecipe(Recipe):
            dest: the destiation
         '''
 
-        # Create data structure to iterate over
-
-        paths = {'source': source,
-                 'dest': dest}
-
-        for pathtype, path in paths.items():
-            if path == ".":
-                paths[pathtype] = os.getcwd()
- 
-            # Warning if doesn't exist
-            if not os.path.exists(path):
-                bot.warning("%s doesn't exist, ensure exists for build" %path)
-
+        def expandPath(path):
+            return os.getcwd() if path == "." else path
+        
+        # Warn the user Singularity doesn't support expansion
+        if source.contains('*'):
+            bot.warning("Singularity doesn't support expansion, * found in %s" % source)
+        
+        # Warning if file/folder (src) doesn't exist
+        if not os.path.exists(source):
+            bot.warning("%s doesn't exist, ensure exists for build" % source)
+        
         # The pair is added to the files as a list
-        self.files.append([paths['source'], paths['dest']])
+        self.files.append([expandPath(source), expandPath(dest)])
 
 
     def _parse_http(self, url, dest):

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.58"
+__version__ = "0.0.59"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
- Fix #101 : Don't warn for destination files
- Fix #102 : warn when using `*` for file expansion in docker. Not supported in singularity till https://github.com/sylabs/singularity/pull/3447

Supersedes #105: Rework function to avoid useless dictionary (checks only make sense for source and expansion was factored out into function)