### PR TITLE
fixing entrypoint accounting for WORKDIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - working directory, the last one defined, should be added to runscript (0.0.61)
  - adding deprecation message for image.export (0.0.60)
    - adding --force option to build
  - fixing warning for files, only relevant for sources (0.0.59)

--- a/spython/main/parse/converters.py
+++ b/spython/main/parse/converters.py
@@ -92,11 +92,11 @@ def create_runscript(self, default="/bin/bash", force=False):
 
     # Entrypoint should use exec
     if not entrypoint.startswith('exec'):
-        entrypoint = "exec %s" %entrypoint
+        entrypoint = "exec %s" % entrypoint
 
     # Should take input arguments into account
     if not re.search('"?[$]@"?', entrypoint):
-        entrypoint = '%s "$@"' %entrypoint
+        entrypoint = '%s "$@"' % entrypoint
     return entrypoint
 
 
@@ -209,6 +209,12 @@ def docker2singularity(self, runscript="/bin/bash", force=False):
 
     # Take preference for user, entrypoint, command, then default
     runscript = self._create_runscript(runscript, force)
+
+    # If a working directory was used, add it as a cd
+    if self.workdir != None:
+        runscript = [self.workdir] + [runscript]
+
+    # Finish the recipe
     recipe += finish_section(runscript, 'runscript')
 
     if self.test is not None:

--- a/spython/main/parse/converters.py
+++ b/spython/main/parse/converters.py
@@ -211,7 +211,7 @@ def docker2singularity(self, runscript="/bin/bash", force=False):
     runscript = self._create_runscript(runscript, force)
 
     # If a working directory was used, add it as a cd
-    if self.workdir != None:
+    if self.workdir is not None:
         runscript = [self.workdir] + [runscript]
 
     # Finish the recipe

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -323,7 +323,7 @@ class DockerRecipe(Recipe):
         # Save the last working directory to add to the runscript
         workdir = self._setup('WORKDIR', line)
         self.workdir = "cd %s" %(''.join(workdir))
-        self.install.append(line)
+        self.install.append(self.workdir)
 
 
 # Entrypoint and Command

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -19,7 +19,9 @@ class DockerRecipe(Recipe):
 
     def __init__(self, recipe=None):
         '''a Docker recipe parses a Docker Recipe into the expected fields of
-           labels, environment, and install/runtime commands
+           labels, environment, and install/runtime commands. We save working
+           directory as we parse, and the last one can be added to the runscript
+           of a Singularity recipe.
 
            Parameters
            ==========
@@ -27,6 +29,7 @@ class DockerRecipe(Recipe):
 
         '''
         self.name = "docker"
+        self.workdir = None
         super(DockerRecipe, self).__init__(recipe)
 
 
@@ -203,7 +206,7 @@ class DockerRecipe(Recipe):
             return os.getcwd() if path == "." else path
         
         # Warn the user Singularity doesn't support expansion
-        if source.contains('*'):
+        if '*' in source:
             bot.warning("Singularity doesn't support expansion, * found in %s" % source)
         
         # Warning if file/folder (src) doesn't exist
@@ -318,8 +321,9 @@ class DockerRecipe(Recipe):
            line: the line from the recipe file to parse for WORKDIR
 
         '''
+        # Save the last working directory to add to the runscript
         workdir = self._setup('WORKDIR', line)
-        line = "cd %s" %(''.join(workdir))
+        self.workdir = "cd %s" %(''.join(workdir))
         self.install.append(line)
 
 

--- a/spython/main/parse/docker.py
+++ b/spython/main/parse/docker.py
@@ -29,7 +29,6 @@ class DockerRecipe(Recipe):
 
         '''
         self.name = "docker"
-        self.workdir = None
         super(DockerRecipe, self).__init__(recipe)
 
 

--- a/spython/main/parse/recipe.py
+++ b/spython/main/parse/recipe.py
@@ -117,6 +117,7 @@ class Recipe(object):
         self.ports = []
         self.test = None
         self.volumes = []
+        self.workdir = None
 
         if self.recipe:
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.60"
+__version__ = "0.0.61"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will fix #114, a quick fix so that the last working directory is honored. For the recipe here, that means that we cd to /code first (shown below).

```
...
# EXPOSE 3031
%environment
export PYTHONUNBUFFERED=1
%runscript
cd /code
exec /bin/bash "$@"
```

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>