### PR TITLE
adding test for entrypoint+cmd and adding proper testing requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - adding test for entrypoint + cmd and fixing testing requirements (0.0.66)
  - fixing bug that inspect does not honor quiet (0.0.65)
  - refactor recipe parsers, writers, and base (0.0.64)
    - paths for files, add, copy, will not be expanded as it adds hardcoded paths

--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,16 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
 from setuptools import setup, find_packages
-import codecs
 import os
 
-##########################################################################################
-# HELPER FUNCTIONS #######################################################################
-##########################################################################################
+################################################################################
+# HELPER FUNCTIONS #############################################################
+################################################################################
 
 def get_lookup():
     '''get version by way of singularity.version, returns a 
-    lookup dictionary with several global variables without
-    needing to import singularity
+       lookup dictionary with several global variables without
+       needing to import spython
     '''
     lookup = dict()
     version_file = os.path.join('spython', 'version.py')
@@ -28,10 +27,9 @@ def get_lookup():
         exec(filey.read(), lookup)
     return lookup
 
-# Read in requirements
 def get_requirements(lookup=None):
     '''get_requirements reads in requirements and versions from
-    the lookup obtained with get_lookup'''
+       the lookup obtained with get_lookup'''
 
     if lookup is None:
         lookup = get_lookup()
@@ -41,12 +39,12 @@ def get_requirements(lookup=None):
         module_name = module[0]
         module_meta = module[1]
         if "exact_version" in module_meta:
-            dependency = "%s==%s" %(module_name,module_meta['exact_version'])
+            dependency = "%s==%s" % (module_name, module_meta['exact_version'])
         elif "min_version" in module_meta:
             if module_meta['min_version'] is None:
                 dependency = module_name
             else:
-                dependency = "%s>=%s" %(module_name,module_meta['min_version'])
+                dependency = "%s>=%s" % (module_name, module_meta['min_version'])
         install_requires.append(dependency)
     return install_requires
 
@@ -66,8 +64,8 @@ PACKAGE_URL = lookup['PACKAGE_URL']
 KEYWORDS = lookup['KEYWORDS']
 DESCRIPTION = lookup['DESCRIPTION']
 LICENSE = lookup['LICENSE']
-with open('README.md') as filey:
-    LONG_DESCRIPTION = filey.read()
+with open('README.md') as readme:
+    LONG_DESCRIPTION = readme.read()
 
 ##########################################################################################
 # MAIN ###################################################################################
@@ -77,6 +75,7 @@ with open('README.md') as filey:
 if __name__ == "__main__":
 
     INSTALL_REQUIRES = get_requirements(lookup)
+    TESTS_REQUIRES = get_requirements(lookup)
 
     setup(name=NAME,
           version=VERSION,
@@ -94,8 +93,8 @@ if __name__ == "__main__":
           long_description_content_type="text/markdown",
           keywords=KEYWORDS,
           setup_requires=["pytest-runner"],
-          tests_require=["pytest"],
-          install_requires = INSTALL_REQUIRES,
+          tests_require=TESTS_REQUIRES,
+          install_requires=INSTALL_REQUIRES,
           classifiers=[
               'Intended Audience :: Science/Research',
               'Intended Audience :: Developers',
@@ -107,4 +106,4 @@ if __name__ == "__main__":
               'Programming Language :: Python :: 3',
           ],
 
-          entry_points = {'console_scripts': [ 'spython=spython.client:main' ] })
+          entry_points={'console_scripts': ['spython=spython.client:main']})

--- a/spython/tests/testdata/docker2singularity/entrypoint-cmd.def
+++ b/spython/tests/testdata/docker2singularity/entrypoint-cmd.def
@@ -1,0 +1,6 @@
+Bootstrap: docker
+From: busybox:latest
+%runscript
+exec python /code/script.py "$@"
+%startscript
+exec python /code/script.py "$@"

--- a/spython/tests/testdata/docker2singularity/entrypoint-cmd.docker
+++ b/spython/tests/testdata/docker2singularity/entrypoint-cmd.docker
@@ -1,0 +1,3 @@
+FROM busybox:latest
+CMD ["/code/script.py"]
+ENTRYPOINT ["python"]

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.65"
+__version__ = "0.0.66"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'
@@ -17,4 +17,10 @@ LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
     ('semver', {'min_version': '2.8.0'}),
+)
+
+TESTS_REQUIRES = (
+    ('pytest', {'min_version': '4.6.2'}),
+    ('pytest-cov', {'min_version': '2.5.1'}),
+    ('pytest-fixtures', {'min_version': '0.1.0'}),
 )


### PR DESCRIPTION
The testing requirements were not fully represented in the setup.py. I'm worried now that there are too many additional dependencies to run basic testing, and perhaps this will come back to bite me. For the meantime the damage is already done, and I'll need to update conda deps too. Right now as is, a user only thinks that pytest is required and won't understand why many of the tests fail. This will also add a test for the entrypoint+cmd conversion in a Dockerfile to Singularity recipe.

I will need to update conda too.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>