### PR TITLE
adding build options argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - adding additional options to build to support singularity-compose (0.0.68)
  - client should support shell (0.0.67)
  - adding test for entrypoint + cmd and fixing testing requirements (0.0.66)
  - fixing bug that inspect does not honor quiet (0.0.65)

--- a/spython/main/build.py
+++ b/spython/main/build.py
@@ -21,7 +21,8 @@ def build(self, recipe=None,
                 ext='sif',
                 sudo=True,
                 stream=False,
-                force=False):
+                force=False,
+                options=None):
 
     '''build a singularity image, optionally for an isolated build
        (requires sudo). If you specify to stream, expect the image name
@@ -44,12 +45,16 @@ def build(self, recipe=None,
                    name (with "image") then a fun robot name will be generated
                    instead. Highly recommended :) 
        sudo: give sudo to the command (or not) default is True for build
-    
+       options: for all other options, specify them in this list.   
     '''
     from spython.utils import check_install
     check_install()
 
     cmd = self._init_command('build')
+
+    # If no extra options
+    if not options:
+        options = []
 
     if 'version 3' in self.version():
         ext = 'sif'
@@ -87,10 +92,10 @@ def build(self, recipe=None,
 
     if sandbox:
         cmd.append('--sandbox')
-    elif sandbox:
+    elif writable:
         cmd.append('--writable')
 
-    cmd = cmd + [image, recipe]
+    cmd = cmd + options + [image, recipe]
 
     if not stream:
         self._run_command(cmd, sudo=sudo, capture=False)


### PR DESCRIPTION
This will give the user more flexibility to specify custom build options (that are also likely to change) to the build command. It will close https://github.com/singularityhub/singularity-cli/issues/132.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>