### PR TITLE
adding quiet (and other args) to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - adding quiet argument to build to override client (0.0.69)
  - adding additional options to build to support singularity-compose (0.0.68)
  - client should support shell (0.0.67)
  - adding test for entrypoint + cmd and fixing testing requirements (0.0.66)

--- a/spython/main/build.py
+++ b/spython/main/build.py
@@ -22,7 +22,9 @@ def build(self, recipe=None,
                 sudo=True,
                 stream=False,
                 force=False,
-                options=None):
+                options=None,
+                quiet=False,
+                return_result=False):
 
     '''build a singularity image, optionally for an isolated build
        (requires sudo). If you specify to stream, expect the image name
@@ -46,6 +48,8 @@ def build(self, recipe=None,
                    instead. Highly recommended :) 
        sudo: give sudo to the command (or not) default is True for build
        options: for all other options, specify them in this list.   
+       quiet: quiet verbose printing from the client.
+       return_result: if True, return complete error code / message dictionary
     '''
     from spython.utils import check_install
     check_install()
@@ -98,7 +102,11 @@ def build(self, recipe=None,
     cmd = cmd + options + [image, recipe]
 
     if not stream:
-        self._run_command(cmd, sudo=sudo, capture=False)
+        self._run_command(cmd, sudo=sudo, 
+                          quiet=quiet, 
+                          return_result=return_result, 
+                          capture=False)
+
     else:
         # Here we return the expected image, and an iterator! 
         # The caller must iterate over

--- a/spython/main/build.py
+++ b/spython/main/build.py
@@ -102,10 +102,11 @@ def build(self, recipe=None,
     cmd = cmd + options + [image, recipe]
 
     if not stream:
-        self._run_command(cmd, sudo=sudo, 
-                          quiet=quiet, 
-                          return_result=return_result, 
-                          capture=False)
+        return self._run_command(cmd, 
+                                 sudo=sudo, 
+                                 quiet=quiet, 
+                                 return_result=return_result, 
+                                 capture=False)
 
     else:
         # Here we return the expected image, and an iterator! 

--- a/spython/main/build.py
+++ b/spython/main/build.py
@@ -102,11 +102,11 @@ def build(self, recipe=None,
     cmd = cmd + options + [image, recipe]
 
     if not stream:
-        return self._run_command(cmd, 
-                                 sudo=sudo, 
-                                 quiet=quiet, 
-                                 return_result=return_result, 
-                                 capture=False)
+        self._run_command(cmd, 
+                          sudo=sudo, 
+                          quiet=quiet, 
+                          return_result=return_result, 
+                          capture=False)
 
     else:
         # Here we return the expected image, and an iterator! 

--- a/spython/version.py
+++ b/spython/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.68"
+__version__ = "0.0.69"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'spython'


### PR DESCRIPTION
This will expose build arguments (quiet, return_result) to the user to allow for more programmatic control of the build. 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>