### PR TITLE
Allow for environment export lines that contain =

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: oci-python-ci
+name: spython-ci
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: oci-python-ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches_ignore: []
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup black linter
+        run: conda create --quiet --name black black
+
+      - name: Lint python code
+        run: |
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          source activate black
+          black --check spython

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - export lines aren't ignored from environment, but replaced (0.0.75)
  - instance logging functions for Singularity 3.5 and up (0.0.74)
  - add sudo_options option to spython.main.Client.build (0.0.73)
  - list of options and writable added to shell, execute, and run (0.0.72)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Singularity Python
 
 [![Build Status](https://travis-ci.org/singularityhub/singularity-cli.svg?branch=master)](https://travis-ci.org/singularityhub/singularity-cli)
+[![GitHub actions status](https://github.com/singularityhub/singularity-cli/workflows/spython-ci/badge.svg?branch=master)](https://github.com/singularityhub/singularity-cli/actions?query=branch%3Amaster+workflow%3Aspython-ci)
 
 Singularity Python (spython) is the Python API for working with <a href="sylabs.io/guides/latest/user-guide/" target="_blank">Singularity</a> containers. See
 the [documentation](https://singularityhub.github.io/singularity-cli) for installation and usage, and

--- a/spython/main/parse/parsers/singularity.py
+++ b/spython/main/parse/parsers/singularity.py
@@ -119,7 +119,7 @@ class SingularityParser(ParserBase):
            lines: A list of environment pair lines.
 
         """
-        environ = [x.replace("export", "").strip() for x in lines if "=" in x]
+        environ = [re.sub("^export", "", x).strip() for x in lines if "=" in x]
         self.recipe.environ += environ
 
     # Files for container

--- a/spython/main/parse/parsers/singularity.py
+++ b/spython/main/parse/parsers/singularity.py
@@ -111,7 +111,7 @@ class SingularityParser(ParserBase):
 
     def _env(self, lines):
         """env will parse a list of environment lines and simply remove any
-           blank lines, or those with export. Dockerfiles don't usually
+           blank lines, and exports. Dockerfiles don't usually
            have exports.
  
            Parameters
@@ -119,7 +119,7 @@ class SingularityParser(ParserBase):
            lines: A list of environment pair lines.
 
         """
-        environ = [x for x in lines if not x.startswith("export")]
+        environ = [x.replace("export", "").strip() for x in lines]
         self.recipe.environ += environ
 
     # Files for container

--- a/spython/main/parse/parsers/singularity.py
+++ b/spython/main/parse/parsers/singularity.py
@@ -119,7 +119,7 @@ class SingularityParser(ParserBase):
            lines: A list of environment pair lines.
 
         """
-        environ = [x.replace("export", "").strip() for x in lines]
+        environ = [x.replace("export", "").strip() for x in lines if "=" in x]
         self.recipe.environ += environ
 
     # Files for container

--- a/spython/tests/test_client.py
+++ b/spython/tests/test_client.py
@@ -29,19 +29,6 @@ def test_export():
     shutil.rmtree(created_sandbox)
 
 
-def test_pull_and_run(tmp_path):
-    pass
-    image = Client.pull("shub://vsoch/singularity-images", pull_folder=str(tmp_path))
-    print(image)
-    assert os.path.exists(image)
-    ext = "sif" if Client.version_info().major >= 3 else "simg"
-    assert image == str(tmp_path / ("singularity-images." + ext))
-
-    result = Client.run(image)
-    print(result)
-    assert "You say please, but all I see is pizza.." in result
-
-
 def test_docker_pull(docker_container):
     tmp_path, container = docker_container
     print(container)

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.74"
+__version__ = "0.0.75"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
Currently, export lines are ignored, the thinking that they look like this:

```bash
VARNAME=thing
export VARNAME
```
however we wouldn't want to ignore this line:

```bash
export VARNAME=thing
```
Instead we would want to replace the export and result in:
```bash
ENV VARNAME=thing
```