### PR TITLE
adding support for instance list to include ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - instance list includes ip address (0.0.76)
  - export lines aren't ignored from environment, but replaced (0.0.75)
  - instance logging functions for Singularity 3.5 and up (0.0.74)
  - add sudo_options option to spython.main.Client.build (0.0.73)

--- a/spython/main/instances.py
+++ b/spython/main/instances.py
@@ -57,9 +57,13 @@ def list_instances(self, name=None, return_json=False, quiet=False, sudo=False):
             print("".join(output["message"]))
 
         # Prepare json result from table
-
-        header = ["daemon_name", "pid", "container_image"]
-        instances = parse_table(output["message"][0], header)
+        # Singularity after 3.5.2 has an added ipaddress
+        try:
+            header = ["daemon_name", "pid", "container_image"]
+            instances = parse_table(output["message"][0], header)
+        except:
+            header = ["daemon_name", "pid", "ip", "container_image"]
+            instances = parse_table(output["message"][0], header)
 
         # Does the user want instance objects instead?
         listing = []

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.75"
+__version__ = "0.0.76"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
Newer versions of Singularity (3.5.2 from master) include the up address in the listing.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>