### PR TITLE
Add library:// url support in spython build/pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - add support for library:// urls (0.0.78)
  - instance stop with timeout argument (0.0.77)
  - instance list includes ip address (0.0.76)
  - export lines aren't ignored from environment, but replaced (0.0.75)

--- a/spython/main/build.py
+++ b/spython/main/build.py
@@ -85,7 +85,7 @@ def build(
             bot.exit("Cannot find %s, exiting." % image)
 
     if image is None:
-        if re.search("(docker|shub)://", recipe) and not robot_name:
+        if re.search("(docker|shub|library)://", recipe) and not robot_name:
             image = self._get_filename(recipe, ext)
         else:
             image = "%s.%s" % (self.RobotNamer.generate(), ext)

--- a/spython/main/pull.py
+++ b/spython/main/pull.py
@@ -57,9 +57,9 @@ def pull(
     if image is None:
         bot.exit("You must provide an image uri, or use client.load() first.")
 
-    # Singularity Only supports shub and Docker pull
-    if not re.search("^(shub|docker)://", image):
-        bot.exit("pull only valid for docker and shub. Use sregistry client.")
+    # Singularity Only supports shub, docker and library pull
+    if not re.search("^(shub|docker|library)://", image):
+        bot.exit("pull only valid for docker, shub and library. Use sregistry client.")
 
     # If we still don't have a custom name, base off of image uri.
     if name is None:

--- a/spython/tests/test_utils.py
+++ b/spython/tests/test_utils.py
@@ -138,6 +138,9 @@ def test_remove_uri():
     assert (
         remove_uri("shub://vanessa/singularity-images") == "vanessa/singularity-images"
     )
+    assert (
+        remove_uri("library://library/default/alpine") == "library/default/alpine"
+    )
     assert remove_uri("vanessa/singularity-images") == "vanessa/singularity-images"
 
 

--- a/spython/tests/test_utils.py
+++ b/spython/tests/test_utils.py
@@ -138,9 +138,7 @@ def test_remove_uri():
     assert (
         remove_uri("shub://vanessa/singularity-images") == "vanessa/singularity-images"
     )
-    assert (
-        remove_uri("library://library/default/alpine") == "library/default/alpine"
-    )
+    assert remove_uri("library://library/default/alpine") == "library/default/alpine"
     assert remove_uri("vanessa/singularity-images") == "vanessa/singularity-images"
 
 

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -230,6 +230,6 @@ def split_uri(container):
 
 
 def remove_uri(container):
-    """remove_uri will remove docker:// or shub:// from the uri
+    """remove_uri will remove docker:// or shub:// or library:// from the uri
     """
     return split_uri(container)[1]

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.77"
+__version__ = "0.0.78"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
Add support for `library://` URLs in spython build and pull #155 