### PR TITLE
Fixing bug that user is replaced anywhere in the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - USER regular expression should check for USER at start of line (0.0.80)
  - add singularity options parameters to send to singularity (0.0.79)
  - add support for library:// urls (0.0.78)
  - instance stop with timeout argument (0.0.77)

--- a/spython/main/parse/writers/singularity.py
+++ b/spython/main/parse/writers/singularity.py
@@ -171,8 +171,8 @@ def finish_section(section, name):
     # Convert USER lines to change user
     lines = []
     for line in section:
-        if "USER" in line:
-            username = line.replace("USER", "").rstrip()
+        if re.search("^USER", line):
+            username = line.replace("USER", "", 1).rstrip()
             line = "su - %s" % username + " # " + line
         lines.append(line)
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.79"
+__version__ = "0.0.80"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
We need to only replace a USER directive from a Dockerfile with a Singularity "equivalent" given that it's found at the beginning of the line, and not somewhere later (used as a different variable!) This will fix #158. 

Signed-off-by: vsoch <vsochat@stanford.edu>