### PR TITLE
🚸 Add `stderr` to generator when streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - USER regular expression should check for USER at start of line (0.0.80)
  - add singularity options parameters to send to singularity (0.0.79)
  - add support for library:// urls (0.0.78)
  - instance stop with timeout argument (0.0.77)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - stream command should print to stdout given CalledProcessError (0.0.81)
  - USER regular expression should check for USER at start of line (0.0.80)
  - add singularity options parameters to send to singularity (0.0.79)
  - add support for library:// urls (0.0.78)

--- a/spython/main/parse/writers/singularity.py
+++ b/spython/main/parse/writers/singularity.py
@@ -171,8 +171,8 @@ def finish_section(section, name):
     # Convert USER lines to change user
     lines = []
     for line in section:
-        if "USER" in line:
-            username = line.replace("USER", "").rstrip()
+        if re.search("^USER", line):
+            username = line.replace("USER", "", 1).rstrip()
             line = "su - %s" % username + " # " + line
         lines.append(line)
 

--- a/spython/tests/test_client.py
+++ b/spython/tests/test_client.py
@@ -7,8 +7,11 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from spython.main import Client
+from spython.utils import write_file
 import shutil
 import os
+import pytest
+from subprocess import CalledProcessError
 
 
 def test_build_from_docker(tmp_path):
@@ -48,6 +51,37 @@ def test_execute_with_return_code(docker_container):
     print(result)
     assert "tmp\nusr\nvar" in result["message"]
     assert result["return_code"] == 0
+
+
+@pytest.mark.parametrize("return_code", [True, False])
+def test_execute_with_called_process_error(
+    capsys, docker_container, return_code, tmp_path
+):
+    tmp_file = os.path.join(tmp_path, "CalledProcessError.sh")
+    # "This is stdout" to stdout, "This is stderr" to stderr
+    script = f"""#!/bin/bash
+echo "This is stdout"
+>&2 echo "This is stderr"
+{"exit 1" if return_code else ""}
+"""
+    write_file(tmp_file, script)
+    if return_code:
+        with pytest.raises(CalledProcessError):
+            for line in Client.execute(
+                docker_container[1], f"/bin/sh {tmp_file}", stream=True
+            ):
+                print(line, "")
+    else:
+        for line in Client.execute(
+            docker_container[1], f"/bin/sh {tmp_file}", stream=True
+        ):
+            print(line, "")
+    captured = capsys.readouterr()
+    assert "stdout" in captured.out
+    if return_code:
+        assert "stderr" in captured.out
+    else:
+        assert "stderr" not in captured.out
 
 
 def test_inspect(docker_container):

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -134,7 +134,12 @@ def stream_command(cmd, no_newline_regexp="Progess", sudo=False, sudo_options=No
     """
     cmd = _process_sudo_cmd(cmd, sudo, sudo_options)
 
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True)
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True
+    )
     for line in iter(process.stdout.readline, ""):
         if not re.search(no_newline_regexp, line):
             yield line

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -135,10 +135,7 @@ def stream_command(cmd, no_newline_regexp="Progess", sudo=False, sudo_options=No
     cmd = _process_sudo_cmd(cmd, sudo, sudo_options)
 
     process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
     )
     for line in iter(process.stdout.readline, ""):
         if not re.search(no_newline_regexp, line):

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -135,7 +135,7 @@ def stream_command(cmd, no_newline_regexp="Progess", sudo=False, sudo_options=No
     cmd = _process_sudo_cmd(cmd, sudo, sudo_options)
 
     process = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
     )
     for line in iter(process.stdout.readline, ""):
         if not re.search(no_newline_regexp, line):
@@ -143,6 +143,7 @@ def stream_command(cmd, no_newline_regexp="Progess", sudo=False, sudo_options=No
     process.stdout.close()
     return_code = process.wait()
     if return_code:
+        print(process.stderr.read())
         raise subprocess.CalledProcessError(return_code, cmd)
 
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.79"
+__version__ = "0.0.80"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.80"
+__version__ = "0.0.81"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When streaming with spython, `stdout` is yielded to a generator, and if the subprocess's `return_code` is not `0`, a `CalledProcessError` is raised. The contents of `stderr` is not passed in either case.

**Describe the solution you'd like**
This pull request adds the contents of `stderr` to `stdout` so the generator contains both in the same sequence as they would be presented if run outside of spython.

**Describe alternatives you've considered**
Alternatively, the contents of stderr could be included in the `CalledProcessError` to give the user details of the exception separate from `stdout`.

**Test your PR locally, and provide the steps necessary to test for the reviewers.**
I'm using this branch in the [develop branch of cpac-python-package](https://github.com/shnizzedy/cpac-python-package/tree/develop), specifically to wrap the ["View crashfiles" series of commands](http://fcp-indi.github.io/docs/user/help#view-crash-files) into 

```sh
cpac --platform singularity crash crash-file.pklz
```
The output of the wrapped command all goes to `stderr`, so without this change, the output stops just past 
```sh
Logging messages will refer to the Singularity paths.
```
With this change, the `stderr` from the pickle is output to the terminal after the logging messages message.

**Additional context**
I was going to point this PR at `develop` (as requested in [CONTRIBUTING](https://github.com/singularityhub/singularity-cli/blob/master/CONTRIBUTING.md#pull-request-process)), but no such branch currently exists. I'm happy to open a new PR to point at a new development branch if that is desired.