### PR TITLE
Ensuring that we dont support multistage builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - Singularity does not support multistage builds (0.0.82)
  - stream command should print to stdout given CalledProcessError (0.0.81)
  - USER regular expression should check for USER at start of line (0.0.80)
  - add singularity options parameters to send to singularity (0.0.79)

--- a/docs/pages/recipes.md
+++ b/docs/pages/recipes.md
@@ -22,6 +22,13 @@ Now we can answer what kind of things might you want to do:
  - convert a Singularity Recipe to a Dockerfile
  - read in a recipe of either type, and modify it before doing the above
 
+**Important** Singularity does not support multistage builds defined within
+a single file, so if your Dockerfile has lines like:
+
+```
+COPY --from=builder  /build/usr/share/gdal/ /usr/share/gdal/
+```
+You should modify the Dockerfile first to remove them.
 
 # Command Line Client
 

--- a/spython/main/parse/parsers/docker.py
+++ b/spython/main/parse/parsers/docker.py
@@ -132,8 +132,10 @@ class DockerParser(ParserBase):
    
         """
         line = self._setup("ARG", line)
-        bot.warning("ARG is not supported for Singularity! To get %s" % line[0])
-        bot.warning("in the container, on host export SINGULARITY_%s" % line[0])
+        bot.warning(
+            "ARG is not supported for Singularity! Add as ENV to the container or export"
+            " SINGULARITYENV_%s on the host." % line[0]
+        )
 
     # Env Parser
 
@@ -216,6 +218,15 @@ class DockerParser(ParserBase):
         lines = self._setup("COPY", lines)
 
         for line in lines:
+
+            # Singularity does not support multistage builds
+            if line.startswith("--from"):
+                bot.warning(
+                    "Singularity does not support multistage builds, skipping COPY %s"
+                    % line
+                )
+                continue
+
             values = line.split(" ")
             topath = values.pop()
             for frompath in values:

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.81"
+__version__ = "0.0.82"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
This issue will close #163, specifically warning the user that multistage builds are not supported, and ensuring that warnings are one per line. This is now the output given the changes - the warnings are moved to one line each, and the --from lines with copy are not supported.

```bash
$ spython recipe Dockerfile > testrecipe.def
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_PROJ_INSTALL_PREFIX=/usr/local on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_BASE_IMAGE=ubuntu:20.04 on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_KEA_VERSION=1.4.13 on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_MONGO_C_DRIVER_VERSION=1.16.2 on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_MONGOCXX_VERSION=3.5.0 on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_TILEDB_VERSION=2.0.2 on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_OPENJPEG_VERSION= on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_RSYNC_REMOTE on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_PROJ_VERSION=master on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_PROJ_INSTALL_PREFIX on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_GDAL_VERSION=master on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_GDAL_RELEASE_DATE on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_GDAL_BUILD_IS_RELEASE on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_PROJ_DATUMGRID_LATEST_LAST_MODIFIED on the host.
WARNING ARG is not supported for Singularity! Add as ENV to the container or export SINGULARITYENV_PROJ_INSTALL_PREFIX on the host.
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build_thirdparty/usr/ /usr/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build${PROJ_INSTALL_PREFIX}/share/proj/ ${PROJ_INSTALL_PREFIX}/share/proj/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build${PROJ_INSTALL_PREFIX}/include/ ${PROJ_INSTALL_PREFIX}/include/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build${PROJ_INSTALL_PREFIX}/bin/ ${PROJ_INSTALL_PREFIX}/bin/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build${PROJ_INSTALL_PREFIX}/lib/ ${PROJ_INSTALL_PREFIX}/lib/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build/usr/share/gdal/ /usr/share/gdal/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build/usr/include/ /usr/include/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build_gdal_python/usr/ /usr/
WARNING Singularity does not support multistage builds, skipping COPY --from=builder  /build_gdal_version_changing/usr/ /usr/

```

Signed-off-by: vsoch <vsochat@stanford.edu>
