### PR TITLE
need to support old daemon_name, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - log error paths are optional (0.1.1)
  - instance list doesn't always include container_image (0.1.0)
  - add sudo_options option to Instance.start/stop and Client.execute (0.0.85)
    - add environ option to Instance.start and Client.execute for passing env variables

--- a/spython/main/instances.py
+++ b/spython/main/instances.py
@@ -77,12 +77,12 @@ def list_instances(
 
                 # Otherwise, add instances to the listing
                 new_instance = self.instance(
-                    pid=i["pid"],
-                    ip_address=i["ip"],
-                    name=i["instance"],
-                    log_err_path=i["logErrPath"],
-                    log_out_path=i["logOutPath"],
-                    image=i.get("img", None),
+                    pid=i.get("pid"),
+                    ip_address=i.get("ip"),
+                    name=i.get("instance") or i.get("daemon_name"),
+                    log_err_path=i.get("logErrPath"),
+                    log_out_path=i.get("logOutPath"),
+                    image=i.get("img") or i.get("container_image"),
                     start=False,
                 )
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
It looks like older versions of singularity don't have the logerr/logout paths for an instance list, so we need to make them all optional.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>