### PR TITLE
Fixing changed behavior with singularity pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - choose output for stream_command (0.0.14)
  - adding support to pull from a url (0.1.13)
  - add more verbosity to instance start/stop (0.1.12)
  - adding more verbosity to running commands (0.1.11)

--- a/spython/main/pull.py
+++ b/spython/main/pull.py
@@ -97,7 +97,9 @@ def pull(
 
         # Option 3: A custom name we can predict (not commit/hash) and can also show
         else:
-            return final_image, stream_command(cmd, sudo=False)
+
+            # As of Singularity 3.x (at least 3.8) output goes to stderr
+            return final_image, stream_command(cmd, sudo=False, output_type="stderr")
 
     if os.path.exists(final_image) and not quiet:
         bot.info(final_image)

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
The previous singularity pull used to write to stdout so it would be possible to see the messages. The current writes completely to stderr, so the default for the pull function stream should be to return that.

Example:

```python
from spython.main import Client

image, stream = Client.pull('docker://busybox', stream=True)
singularity pull --name busybox.sif docker://busybox

for line in stream:
    print(line.strip())

# here is the content of the lines
INFO:    Converting OCI blobs to SIF format
INFO:    Starting build...
Getting image source signatures
Copying blob sha256:b71f96345d44b237decc0c2d6c2f9ad0d17fde83dad7579608f1f0764d9686f2
Copying config sha256:37c1493cd5ea164a5fc4ea85b649851682ca5a954f3d301530042af65290a5c7
Writing manifest to image destination
Storing signatures
2021/06/17 21:45:23  info unpack layer: sha256:b71f96345d44b237decc0c2d6c2f9ad0d17fde83dad7579608f1f0764d9686f2
INFO:    Creating SIF file...
```

Signed-off-by: vsoch <vsoch@users.noreply.github.com>