### PR TITLE
Ensuring options and args are used if set from instance init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - ensure options and args from instance init are honored (0.0.15)
  - choose output for stream_command (0.0.14)
  - adding support to pull from a url (0.1.13)
  - add more verbosity to instance start/stop (0.1.12)

--- a/spython/instance/__init__.py
+++ b/spython/instance/__init__.py
@@ -28,7 +28,8 @@ class Instance(ImageBase):
 
         # Update metadats from arguments
         self._update_metadata(kwargs)
-        self.options = []
+        self.options = kwargs.get("options", [])
+        self.args = kwargs.get("args", [])
         self.cmd = []
         self.quiet = quiet
 

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -63,6 +63,10 @@ def start(
 
     cmd = self._init_command(subgroup, singularity_options)
 
+    # Set options and args
+    args = args or self.args
+    options = options or self.options
+
     # Add options, if they are provided
     if not isinstance(options, list):
         options = [] if options is None else options.split(" ")

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
This will address #178. It's hard to open a PR on airflow so hopefully we can fix the bug over here!
Signed-off-by: vsoch <vsoch@users.noreply.github.com