### PR TITLE
Fixing parsing bug with singularity cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
- - ensure options and args from instance init are honored (0.0.15)
- - choose output for stream_command (0.0.14)
+ - fixing bug with defining comments earlier (0.1.16)
+ - ensure options and args from instance init are honored (0.1.15)
+ - choose output for stream_command (0.1.14)
  - adding support to pull from a url (0.1.13)
  - add more verbosity to instance start/stop (0.1.12)
  - adding more verbosity to running commands (0.1.11)

--- a/spython/main/parse/parsers/singularity.py
+++ b/spython/main/parse/parsers/singularity.py
@@ -304,6 +304,8 @@ class SingularityParser(ParserBase):
         lines = self.lines[:]
         fromHeader = None
         stage = None
+        section = None
+        comments = []
 
         while lines:
 
@@ -314,8 +316,6 @@ class SingularityParser(ParserBase):
             # Bootstrap Line
             if re.search("bootstrap", line, re.IGNORECASE):
                 self._check_bootstrap(stripped)
-                section = None
-                comments = []
 
             # From Line
             elif re.search("from:", stripped, re.IGNORECASE):

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"


### PR DESCRIPTION
currently, it is assumed the comments and sections come after the header. However, we
need to allow comments before because it is not unheard of (although it seems rare). This will fix #180 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>