### PR TITLE
silence deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - updating CI/tests and fixing deprecations (warnings) (0.1.17)
  - fixing bug with defining comments earlier (0.1.16)
  - ensure options and args from instance init are honored (0.1.15)
  - choose output for stream_command (0.1.14)

--- a/spython/main/parse/parsers/base.py
+++ b/spython/main/parse/parsers/base.py
@@ -155,6 +155,6 @@ class ParserBase(object):
         string: the string with replacements made
         """
         for key, value in args.items():
-            if re.search("\$(" + key + "|\{[^}]*\})", string):
-                string = re.sub("\$(" + key + "|\{[^}]*\})", value, string)
+            if re.search(r"\$(" + key + r"|\{[^}]*\})", string):
+                string = re.sub(r"\$(" + key + r"|\{[^}]*\})", value, string)
         return string

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -102,7 +102,7 @@ def get_singularity_version_info():
         version_string = version_string[len(prefix) :]
     elif "/" in version_string:  # Handle old stuff like "x.y.z-pull/123-0a5d"
         version_string = version_string.replace("/", "+", 1)
-    return semver.parse_version_info(version_string)
+    return semver.VersionInfo.parse(version_string)
 
 
 def get_installdir():

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "spython"
@@ -14,6 +14,6 @@ KEYWORDS = "singularity python client (spython)"
 DESCRIPTION = "Command line python tool for working with singularity."
 LICENSE = "LICENSE"
 
-INSTALL_REQUIRES = (("semver", {"min_version": "2.8.0"}),)
+INSTALL_REQUIRES = (("semver", {"min_version": "2.8.1"}),)
 
 TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)


### PR DESCRIPTION
they show up for:

* re (python 3.9.7)
* semver 2.13.0