### PR TITLE
Add check for Apptainer to fix pull_folder

### DIFF
--- a/spython/main/pull.py
+++ b/spython/main/pull.py
@@ -72,7 +72,7 @@ def pull(
 
         # Regression Singularity 3.* onward, PULLFOLDER not honored
         # https://github.com/sylabs/singularity/issues/2788
-        if ("version 3" in self.version()) or ('apptainer' in self.version()):
+        if ("version 3" in self.version()) or ("apptainer" in self.version()):
             name = final_image
             pull_folder = None  # Don't use pull_folder
     else:

--- a/spython/main/pull.py
+++ b/spython/main/pull.py
@@ -72,7 +72,7 @@ def pull(
 
         # Regression Singularity 3.* onward, PULLFOLDER not honored
         # https://github.com/sylabs/singularity/issues/2788
-        if "version 3" in self.version():
+        if ("version 3" in self.version()) or ('apptainer' in self.version()):
             name = final_image
             pull_folder = None  # Don't use pull_folder
     else:


### PR DESCRIPTION
This is intended to fix [issue #522 in SHPC](https://github.com/singularityhub/singularity-hpc/issues/522).

# The Problem

Since Apptainer is forked from Singularity 3+, it needs to be included in the check for Singularity 3+ in the pull function:

```python
if pull_folder:
        final_image = os.path.join(pull_folder, os.path.basename(name))

        # Regression Singularity 3.* onward, PULLFOLDER not honored
        # https://github.com/sylabs/singularity/issues/2788
        if "version 3" in self.version(): <---- HERE!!
            name = final_image
            pull_folder = None  # Don't use pull_folder
    else:
        final_image = name
```

Otherwise, containers are pulled to $PWD instead of the intended `pull_folder`.

# The Fix

Just add a check for apptainer as well:

```python
if pull_folder:
        final_image = os.path.join(pull_folder, os.path.basename(name))

        # Regression Singularity 3.* onward, PULLFOLDER not honored
        # https://github.com/sylabs/singularity/issues/2788
        if ("version 3" in self.version()) or ("apptainer" in self.version()):
            name = final_image
            pull_folder = None  # Don't use pull_folder
    else:
        final_image = name
```