### PR TITLE
Match WORKDIR function in Dockerfile when converting to singularity recipe

### DIFF
--- a/spython/main/parse/parsers/docker.py
+++ b/spython/main/parse/parsers/docker.py
@@ -425,6 +425,8 @@ class DockerParser(ParserBase):
         """
         # Save the last working directory to add to the runscript
         workdir = self._setup("WORKDIR", line)
+        workdir_mkdir = "mkdir -p %s" % ("".join(workdir))
+        self.recipe[self.active_layer].install.append(workdir_mkdir)
         workdir_cd = "cd %s" % ("".join(workdir))
         self.recipe[self.active_layer].install.append(workdir_cd)
         self.recipe[self.active_layer].workdir = workdir[0]


### PR DESCRIPTION
Dockerfile WORKDIR creates a directory if it does not exist.   spython recipe conversion previously only generates "cd {dir}"

This adds "mkdir -p {dir}" before the "cd" to match the WORKDIR semantics in Dockerfiles.
