### PR TITLE
Fix setup.py readme encoding 😁️

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ PACKAGE_URL = lookup["PACKAGE_URL"]
 KEYWORDS = lookup["KEYWORDS"]
 DESCRIPTION = lookup["DESCRIPTION"]
 LICENSE = lookup["LICENSE"]
-with open("README.md") as readme:
+with open("README.md", encoding="utf-8") as readme:
     LONG_DESCRIPTION = readme.read()
 
 ##########################################################################################


### PR DESCRIPTION
Hi,

this package fails to install on windows as `open` falls back to the system encoding (which is not UTF-8 on windows).

This crash is caused by '😁️' in readme.md:

```sh
Processing c:\users\me\projects\cmi\singularity-cli
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\me\Projects\cmi\singularity-cli\setup.py", line 69, in <module>
          LONG_DESCRIPTION = readme.read()
        File "C:\Users\me\anaconda3\envs\cpac_python\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1262: character maps to <undefined>
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
```

(😁️ is `0xF0 0x9F 0x98 0x81` in UTF-8)

This PR sets UTF-8 as the correct encoding in `setup.py`.

Cheers,
😁️