### PR TITLE
Expose the output_type option when streaming, and allow both stdout/stderr to be captured

### DIFF
--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -1,4 +1,4 @@
 pre-commit
-black
+black==23.3.0
 isort
 flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - exposed the stream type option, and ability to capture both stdout and stderr when stream=True (0.3.1)
  - dropping support for Singularity 2.x (0.3.0)
  - add comment out of STOPSIGNAL (0.2.14)
  - sudo `-E` flag should not be provided by default (0.2.13)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ with open("README.md") as readme:
 
 
 if __name__ == "__main__":
-
     INSTALL_REQUIRES = get_requirements(lookup)
     TESTS_REQUIRES = get_requirements(lookup)
 

--- a/spython/client/__init__.py
+++ b/spython/client/__init__.py
@@ -13,7 +13,6 @@ import sys
 
 
 def get_parser():
-
     parser = argparse.ArgumentParser(
         description="Singularity Client",
         formatter_class=argparse.RawTextHelpFormatter,
@@ -147,7 +146,6 @@ def version():
 
 
 def main():
-
     parser = get_parser()
 
     def print_help(return_code=0):

--- a/spython/client/recipe.py
+++ b/spython/client/recipe.py
@@ -74,7 +74,6 @@ def main(args, options, parser):
         force = True
 
     if args.json:
-
         if outfile is not None:
             if not os.path.exists(outfile):
                 if force:
@@ -85,7 +84,6 @@ def main(args, options, parser):
             print(json.dumps(recipeParser.recipe.json(), indent=4))
 
     else:
-
         # Do the conversion
         recipeWriter = writer(recipeParser.recipe)
         result = recipeWriter.convert(runscript=entrypoint, force=force)

--- a/spython/instance/__init__.py
+++ b/spython/instance/__init__.py
@@ -93,7 +93,6 @@ class Instance(ImageBase):
 
         # Add acceptable arguments
         for arg in ["pid", "name", "ip_address", "log_err_path", "log_out_path", "img"]:
-
             # Skip over non-iterables:
             if arg in kwargs:
                 setattr(self, arg, kwargs[arg])

--- a/spython/instance/cmd/start.py
+++ b/spython/instance/cmd/start.py
@@ -49,7 +49,6 @@ def start(
 
     # If an image isn't provided, we have an initialized instance
     if image is None:
-
         # Not having this means it was called as a command, without an image
         if not hasattr(self, "_image"):
             bot.exit("Please provide an image, or create an Instance first.")

--- a/spython/main/base/command.py
+++ b/spython/main/base/command.py
@@ -66,7 +66,6 @@ def generate_bind_list(self, bindlist=None):
         bindlist = bindlist.split(" ")
 
     for bind in bindlist:
-
         # Still cannot be None
         if bind:
             bot.debug("Adding bind %s" % bind)
@@ -113,7 +112,6 @@ def run_command(
     environ=None,
     background=False,
 ):
-
     """
     Run_command is a wrapper for the global run_command, checking first
     for sudo and exiting on error if needed. The message is returned as

--- a/spython/main/base/generate.py
+++ b/spython/main/base/generate.py
@@ -11,7 +11,6 @@ from random import choice
 
 
 class RobotNamer:
-
     _descriptors = [
         "chunky",
         "buttery",

--- a/spython/main/build.py
+++ b/spython/main/build.py
@@ -31,7 +31,6 @@ def build(
     sudo_options=None,
     singularity_options=None,
 ):
-
     """build a singularity image, optionally for an isolated build
     (requires sudo). If you specify to stream, expect the image name
     and an iterator to be returned.

--- a/spython/main/execute.py
+++ b/spython/main/execute.py
@@ -29,7 +29,7 @@ def execute(
     sudo_options=None,
     quiet=True,
     environ=None,
-    stream_type="stdout"
+    stream_type="stdout",
 ):
     """execute: send a command to a container
 
@@ -52,7 +52,7 @@ def execute(
                    and message result not (default)
     quiet: Do not print verbose output.
     environ: extra environment to add.
-    stream_type: Sets which output stream from the singularity command should be return. Values are 'stdout', 'stderr', 'both'. 
+    stream_type: Sets which output stream from the singularity command should be return. Values are 'stdout', 'stderr', 'both'.
     """
     from spython.utils import check_install
 
@@ -70,7 +70,6 @@ def execute(
         image = None
 
     if command is not None:
-
         # No image provided, default to use the client's loaded image
         if image is None:
             image = self._get_uri()
@@ -117,7 +116,9 @@ def execute(
                 quiet=quiet,
                 environ=environ,
             )
-        return stream_command(cmd, sudo=sudo, sudo_options=sudo_options, output_type=stream_type)
+        return stream_command(
+            cmd, sudo=sudo, sudo_options=sudo_options, output_type=stream_type
+        )
 
     bot.exit("Please include a command (list) to execute.")
 

--- a/spython/main/execute.py
+++ b/spython/main/execute.py
@@ -29,6 +29,7 @@ def execute(
     sudo_options=None,
     quiet=True,
     environ=None,
+    stream_type="stdout"
 ):
     """execute: send a command to a container
 
@@ -51,6 +52,7 @@ def execute(
                    and message result not (default)
     quiet: Do not print verbose output.
     environ: extra environment to add.
+    stream_type: Sets which output stream from the singularity command should be return. Values are 'stdout', 'stderr', 'both'. 
     """
     from spython.utils import check_install
 
@@ -115,7 +117,7 @@ def execute(
                 quiet=quiet,
                 environ=environ,
             )
-        return stream_command(cmd, sudo=sudo, sudo_options=sudo_options)
+        return stream_command(cmd, sudo=sudo, sudo_options=sudo_options, output_type=stream_type)
 
     bot.exit("Please include a command (list) to execute.")
 

--- a/spython/main/export.py
+++ b/spython/main/export.py
@@ -19,7 +19,6 @@ def export(
     sudo=False,
     singularity_options=None,
 ):
-
     """export will export an image, sudo must be used. Since we have Singularity
     versions after 3, export is replaced with building into a sandbox.
 

--- a/spython/main/instances.py
+++ b/spython/main/instances.py
@@ -63,7 +63,6 @@ def list_instances(
     # Success, we have instances
 
     if output["return_code"] == 0:
-
         instances = json.loads(output["message"][0]).get("instances", {})
 
         # Does the user want instance objects instead?
@@ -71,7 +70,6 @@ def list_instances(
 
         if not return_json:
             for i in instances:
-
                 # If the user has provided a name, only add instance matches
                 if name is not None:
                     if name != i["instance"]:

--- a/spython/main/parse/parsers/base.py
+++ b/spython/main/parse/parsers/base.py
@@ -48,7 +48,6 @@ class ParserBase:
         self.recipe = {"spython-base": Recipe(self.filename)}
 
         if self.filename:
-
             # Read in the raw lines of the file
             self.lines = read_file(self.filename)
 
@@ -69,7 +68,6 @@ class ParserBase:
         attempting parsing.
         """
         if self.filename is not None:
-
             # Does the recipe provided exist?
             if not os.path.exists(self.filename):
                 bot.exit("Cannot find %s, is the path correct?" % self.filename)

--- a/spython/main/parse/parsers/docker.py
+++ b/spython/main/parse/parsers/docker.py
@@ -14,7 +14,6 @@ from .base import ParserBase
 
 
 class DockerParser(ParserBase):
-
     name = "docker"
 
     def __init__(self, filename="Dockerfile", load=True):
@@ -49,7 +48,6 @@ class DockerParser(ParserBase):
         previous = None
 
         for line in self.lines:
-
             parser = self._get_mapping(line, parser, previous)
 
             # Parse it, if appropriate
@@ -147,7 +145,6 @@ class DockerParser(ParserBase):
 
         # Try to extract arguments from the line
         for arg in line:
-
             # An undefined arg cannot be used
             if "=" not in arg:
                 bot.warning(
@@ -197,7 +194,6 @@ class DockerParser(ParserBase):
         exports = []
 
         for env in envlist:
-
             pieces = re.split("( |\\\".*?\\\"|'.*?')", env)
             pieces = [p for p in pieces if p.strip()]
 
@@ -205,7 +201,6 @@ class DockerParser(ParserBase):
                 current = pieces.pop(0)
 
                 if current.endswith("="):
-
                     # Case 1: ['A='] --> A=
                     nextone = ""
 
@@ -243,7 +238,6 @@ class DockerParser(ParserBase):
         lines = self._setup("COPY", lines)
 
         for line in lines:
-
             # Take into account multistage builds
             layer = None
             if line.startswith("--from"):

--- a/spython/main/parse/parsers/singularity.py
+++ b/spython/main/parse/parsers/singularity.py
@@ -13,7 +13,6 @@ from .base import ParserBase
 
 
 class SingularityParser(ParserBase):
-
     name = "singularity"
 
     def __init__(self, filename="Singularity", load=True):
@@ -51,7 +50,6 @@ class SingularityParser(ParserBase):
         bot.warning("SETUP is error prone, please check output.")
 
         for line in lines:
-
             # For all lines, replace rootfs with actual root /
             line = re.sub("[$]{?SINGULARITY_ROOTFS}?", "", "$SINGULARITY_ROOTFS")
 
@@ -171,7 +169,6 @@ class SingularityParser(ParserBase):
 
         # Multiple line runscript needs multiple lines written to script
         if len(lines) > 1:
-
             bot.warning("More than one line detected for runscript!")
             bot.warning("These will be echoed into a single script to call.")
             self._write_script("/entrypoint.sh", lines)
@@ -257,7 +254,6 @@ class SingularityParser(ParserBase):
         members = []
 
         while True:
-
             if not lines:
                 break
             next_line = lines[0]
@@ -278,7 +274,6 @@ class SingularityParser(ParserBase):
 
         # Add the list to the config
         if members and section is not None:
-
             # Get the correct parsing function
             parser = self._get_mapping(section)
 
@@ -309,7 +304,6 @@ class SingularityParser(ParserBase):
         comments = []
 
         while lines:
-
             # Clean up white trailing/leading space
             line = lines.pop(0)
             stripped = line.strip()

--- a/spython/main/parse/recipe.py
+++ b/spython/main/parse/recipe.py
@@ -23,7 +23,6 @@ class Recipe:
     """
 
     def __init__(self, recipe=None, layer=1):
-
         self.cmd = None
         self.comments = []
         self.entrypoint = None

--- a/spython/main/parse/writers/docker.py
+++ b/spython/main/parse/writers/docker.py
@@ -45,7 +45,6 @@ _default_uri = re.compile(
 
 
 class DockerWriter(WriterBase):
-
     name = "docker"
 
     def __init__(self, recipe=None):  # pylint: disable=useless-super-delegation
@@ -161,7 +160,6 @@ def write_lines(label, lines):
     result = []
     continued = False
     for line in lines:
-
         # Skip comments and empty lines
         if line.strip() == "" or line.strip().startswith("#"):
             continue

--- a/spython/main/parse/writers/singularity.py
+++ b/spython/main/parse/writers/singularity.py
@@ -13,7 +13,6 @@ from .base import WriterBase
 
 
 class SingularityWriter(WriterBase):
-
     name = "singularity"
 
     def __init__(self, recipe=None):  # pylint: disable=useless-super-delegation
@@ -52,7 +51,6 @@ class SingularityWriter(WriterBase):
 
         # Write each layer to new file
         for stage, parser in self.recipe.items():
-
             # Set the first and active stage
             self.stage = stage
 
@@ -111,9 +109,7 @@ class SingularityWriter(WriterBase):
 
         # Only look at Docker if not enforcing default
         if not force:
-
             if self.recipe[self.stage].entrypoint is not None:
-
                 # The provided entrypoint can be a string or a list
                 if isinstance(self.recipe[self.stage].entrypoint, list):
                     entrypoint = " ".join(self.recipe[self.stage].entrypoint)

--- a/spython/main/pull.py
+++ b/spython/main/pull.py
@@ -24,7 +24,6 @@ def pull(
     quiet=False,
     singularity_options=None,
 ):
-
     """pull will pull a singularity hub or Docker image
 
     Parameters
@@ -92,7 +91,6 @@ def pull(
 
         # Option 3: A custom name we can predict (not commit/hash) and can also show
         else:
-
             # As of Singularity 3.x (at least 3.8) output goes to stderr
             return final_image, stream_command(cmd, sudo=False, output_type="stderr")
 

--- a/spython/oci/__init__.py
+++ b/spython/oci/__init__.py
@@ -9,7 +9,6 @@ from spython.logger import bot
 
 
 class OciImage(ImageBase):
-
     # Default functions of client don't use sudo
     sudo = False
 

--- a/spython/oci/cmd/actions.py
+++ b/spython/oci/cmd/actions.py
@@ -19,7 +19,6 @@ def run(
     singularity_options=None,
     log_format="kubernetes",
 ):
-
     """run is a wrapper to create, start, attach, and delete a container.
 
     Equivalent command line example:
@@ -57,7 +56,6 @@ def create(
     log_format="kubernetes",
     singularity_options=None,
 ):
-
     """use the client to create a container from a bundle directory. The bundle
     directory should have a config.json. You must be the root user to
     create a runtime.
@@ -104,7 +102,6 @@ def _run(
     log_format="kubernetes",
     singularity_options=None,
 ):
-
     """_run is the base function for run and create, the only difference
     between the two being that run does not have an option for sync_socket.
 

--- a/spython/oci/cmd/states.py
+++ b/spython/oci/cmd/states.py
@@ -11,7 +11,6 @@ import json
 def state(
     self, container_id=None, sudo=None, sync_socket=None, singularity_options=None
 ):
-
     """get the state of an OciImage, if it exists. The optional states that
     can be returned are created, running, stopped or (not existing).
 
@@ -47,7 +46,6 @@ def state(
     result = self._run_command(cmd, sudo=sudo, quiet=True)
 
     if result is not None:
-
         # If successful, a string is returned to parse
         if isinstance(result, str):
             return json.loads(result)
@@ -56,7 +54,6 @@ def state(
 def _state_command(
     self, container_id=None, command="start", sudo=None, singularity_options=None
 ):
-
     """A generic state command to wrap pause, resume, kill, etc., where the
     only difference is the command. This function will be unwrapped if the
     child functions get more complicated (with additional arguments).
@@ -90,7 +87,6 @@ def _state_command(
 
 
 def start(self, container_id=None, sudo=None, singularity_options=None):
-
     """start a previously invoked OciImage, if it exists.
 
     Equivalent command line example:
@@ -112,7 +108,6 @@ def start(self, container_id=None, sudo=None, singularity_options=None):
 
 
 def kill(self, container_id=None, sudo=None, signal=None, singularity_options=None):
-
     """stop (kill) a started OciImage container, if it exists
 
     Equivalent command line example:

--- a/spython/tests/test_client.py
+++ b/spython/tests/test_client.py
@@ -64,20 +64,25 @@ def test_execute_with_return_code(docker_container):
     assert "tmp\nusr\nvar" in result["message"]
     assert result["return_code"] == 0
 
+
 def test_execute_with_stream(docker_container):
     output = Client.execute(docker_container[1], "ls /", stream=True)
     message = "".join(list(output))
     assert "tmp\nusr\nvar" in message
-    
-    output = Client.execute(docker_container[1], "ls /", stream=True, stream_type="both")
+
+    output = Client.execute(
+        docker_container[1], "ls /", stream=True, stream_type="both"
+    )
     message = "".join(list(output))
     assert "tmp\nusr\nvar" in message
-    
+
     # ls / should be successful, so there will be no stderr
-    output = Client.execute(docker_container[1], "ls /", stream=True, stream_type="stderr")
+    output = Client.execute(
+        docker_container[1], "ls /", stream=True, stream_type="stderr"
+    )
     message = "".join(list(output))
     assert "tmp\nusr\nvar" not in message
-    
+
 
 @pytest.mark.parametrize("return_code", [True, False])
 def test_execute_with_called_process_error(

--- a/spython/tests/test_client.py
+++ b/spython/tests/test_client.py
@@ -64,6 +64,20 @@ def test_execute_with_return_code(docker_container):
     assert "tmp\nusr\nvar" in result["message"]
     assert result["return_code"] == 0
 
+def test_execute_with_stream(docker_container):
+    output = Client.execute(docker_container[1], "ls /", stream=True)
+    message = "".join(list(output))
+    assert "tmp\nusr\nvar" in message
+    
+    output = Client.execute(docker_container[1], "ls /", stream=True, stream_type="both")
+    message = "".join(list(output))
+    assert "tmp\nusr\nvar" in message
+    
+    # ls / should be successful, so there will be no stderr
+    output = Client.execute(docker_container[1], "ls /", stream=True, stream_type="stderr")
+    message = "".join(list(output))
+    assert "tmp\nusr\nvar" not in message
+    
 
 @pytest.mark.parametrize("return_code", [True, False])
 def test_execute_with_called_process_error(

--- a/spython/tests/test_conversion.py
+++ b/spython/tests/test_conversion.py
@@ -48,7 +48,6 @@ def test_docker2singularity(test_data, tmp_path):
 
 
 def test_singularity2docker(test_data, tmp_path):
-
     print("Testing spython conversion from singularity2docker")
     from spython.main.parse.parsers import SingularityParser
     from spython.main.parse.writers import DockerWriter

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -122,12 +122,14 @@ def stream_command(
     sudo_options: string or list of strings that will be passed as options to sudo
 
     """
-    if output_type not in ["stdout", "stderr"]:
+    if output_type not in ["stdout", "stderr", "both"]:
         bot.exit("Invalid output type %s. Must be stderr or stdout." % output_type)
     cmd = _process_sudo_cmd(cmd, sudo, sudo_options)
 
+    stderr_pipe = subprocess.STDOUT if output_type == "both" else subprocess.PIPE
+
     process = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+        cmd, stdout=subprocess.PIPE, stderr=stderr_pipe, universal_newlines=True
     )
 
     # Allow the runner to choose streaming output or error

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -123,7 +123,9 @@ def stream_command(
 
     """
     if output_type not in ["stdout", "stderr", "both"]:
-        bot.exit("Invalid output type %s. Must be stderr, stdout or both." % output_type)
+        bot.exit(
+            "Invalid output type %s. Must be stderr, stdout or both." % output_type
+        )
     cmd = _process_sudo_cmd(cmd, sudo, sudo_options)
 
     stderr_pipe = subprocess.STDOUT if output_type == "both" else subprocess.PIPE
@@ -160,7 +162,6 @@ def run_command(
     environ=None,
     background=False,
 ):
-
     """
     run_command uses subprocess to send a command to the terminal. If
     capture is True, we use the parent stdout, so the progress bar (and

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -123,7 +123,7 @@ def stream_command(
 
     """
     if output_type not in ["stdout", "stderr", "both"]:
-        bot.exit("Invalid output type %s. Must be stderr or stdout." % output_type)
+        bot.exit("Invalid output type %s. Must be stderr, stdout or both." % output_type)
     cmd = _process_sudo_cmd(cmd, sudo, sudo_options)
 
     stderr_pipe = subprocess.STDOUT if output_type == "both" else subprocess.PIPE

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "spython"


### PR DESCRIPTION
This is an untested PR, but one I hope is fairly straightforward. I have a container whose program within it only outputs on the stderr. When streaming I am via the `Client.execute` method I am unable to capture these messages and log them. 

This PR aims to:
- expose the output_type option in execute (I have called it stream_type for clarity in the call into execute)
- ability to stream both the stdout and stderr. 
?
Would someone be able to give this a look over and test?