### PR TITLE
test for stderr before printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - added check to enbsure stderr exists upon a non-zero return code when streaming (0.3.2)
  - exposed the stream type option, and ability to capture both stdout and stderr when stream=True (0.3.1)
  - dropping support for Singularity 2.x (0.3.0)
  - add comment out of STOPSIGNAL (0.2.14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
- - added check to enbsure stderr exists upon a non-zero return code when streaming (0.3.2)
+ - added check to enbsure stderr exists upon a non-zero return code when streaming (0.3.11)
  - exposed the stream type option, and ability to capture both stdout and stderr when stream=True (0.3.1)
  - dropping support for Singularity 2.x (0.3.0)
  - add comment out of STOPSIGNAL (0.2.14)

--- a/spython/utils/terminal.py
+++ b/spython/utils/terminal.py
@@ -148,7 +148,10 @@ def stream_command(
     process.stdout.close()
     return_code = process.wait()
     if return_code:
-        print(process.stderr.read(), file=sys.stderr)
+        # Some situations may return process without an attached stderr object
+        # to read from
+        if process.stderr:
+            print(process.stderr.read(), file=sys.stderr)
         raise subprocess.CalledProcessError(return_code, cmd)
 
 

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.3.2"
+__version__ = "0.3.11"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "spython"

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "spython"


### PR DESCRIPTION
As discussed, sometimes an error is raised when there is no `stderr` attached to the `process` object. This will test to ensure it does exist before trying to read from it. 