### PR TITLE
do not change instance name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "spython" (and eventually to
 singularity on pypi), and the versions here will coincide with these releases.
 
 ## [master](https://github.com/singularityhub/singularity-cli/tree/master)
+ - do not modify user provided instance name when generating new instance (0.3.13)
  - bug with instance.run_command (0.3.12)
  - added check to enbsure stderr exists upon a non-zero return code when streaming (0.3.11)
  - exposed the stream type option, and ability to capture both stdout and stderr when stream=True (0.3.1)

--- a/spython/instance/__init__.py
+++ b/spython/instance/__init__.py
@@ -47,7 +47,10 @@ class Instance(ImageBase):
         # If no name provided, use robot name
         if name is None:
             name = self.RobotNamer.generate()
-        self.name = name.replace("-", "_")
+        # dash allowed in instance name.
+        # authorizedChars = `^[a-zA-Z0-9._-]+$` from instance_linux.go
+        #self.name = name.replace("-", "_")
+        self.name = name
 
     def parse_image_name(self, image):
         """

--- a/spython/instance/__init__.py
+++ b/spython/instance/__init__.py
@@ -49,7 +49,7 @@ class Instance(ImageBase):
             name = self.RobotNamer.generate()
         # dash allowed in instance name.
         # authorizedChars = `^[a-zA-Z0-9._-]+$` from instance_linux.go
-        #self.name = name.replace("-", "_")
+        # self.name = name.replace("-", "_")
         self.name = name
 
     def parse_image_name(self, image):

--- a/spython/version.py
+++ b/spython/version.py
@@ -5,7 +5,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.3.12"
+__version__ = "0.3.13"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "spython"


### PR DESCRIPTION
singularity-cli change provided instance name when it contains a dash to name with underscore.

dash is legit in instance name (see: `authorizedChars`  regexp in https://github.com/sylabs/singularity/blob/main/internal/pkg/instance/instance_linux.go#L69)

so do not change the name and delegate instance name validation to singularity.

regards

Eric